### PR TITLE
Removed removed repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
             <id>Vaadin prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
         </repository>
-        <!-- Repository needed for the snapshot versions of Vaadin -->
-        <repository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -79,13 +74,6 @@
         <pluginRepository>
             <id>Vaadin prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Gives 503:s these days, slows down the build a lot if e.g. using

 mvn versions:set-property -Dproperty=vaadin.version -DnewVersion=25.0.5

I added your project to verification build setup and it takes a lot of time there...

BTW. I'd suggest to remove all the repositories from the pom.xml unless you really need those, I don't see why you would.

If you want to test against vaadin snapshots (available in pre-release repo if you need them) or alpha releases, my suggestion is to have a profile in your settings.xml (or in project pom.xml, but not enabled by default).