### PR TITLE
fix: ValueChangeEvent returns new value via getValue() (#85)

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -297,8 +297,12 @@ public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel 
 
     @Override
     public void setValue(String value) {
-        super.setValue(value);
-        this.editorData = value != null ? value : "";
+        // 先规范化 null 为 ""，再交给 super.setValue。
+        // 否则事件构造时 getValue() 会读到 null（presentation 阶段写入），
+        // 而方法返回后 getValue() 又变为 ""，导致监听器值与最终值不一致（与 issue #85 同源）。
+        String newValue = value != null ? value : "";
+        this.editorData = newValue;
+        super.setValue(newValue);
         getElement().setProperty("editorData", this.editorData);
         updateEditorData(this.editorData);
     }
@@ -311,10 +315,15 @@ public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel 
         if (java.util.Objects.equals(oldValue, newValue)) {
             return;
         }
-        // super.setModelValue already fires ValueChangeEvent via Vaadin's AbstractField,
-        // so we must not call fireEvent again to avoid duplicate events
-        super.setModelValue(newValue, fromClient);
+        // 必须先更新 editorData，再调用 super.setModelValue。
+        // 原因：本类重写了 getValue() 返回 editorData，而 Vaadin 在
+        // ComponentValueChangeEvent 构造时会调用 getValue() 读取新值
+        // （见 AbstractField.ComponentValueChangeEvent，this.value = hasValue.getValue()）。
+        // 若先 fire 事件再赋值，监听器拿到的将是旧内容（issue #85）。
         this.editorData = newValue;
+        // super.setModelValue 会经由 Vaadin 的 AbstractField 触发 ValueChangeEvent，
+        // 因此不能再额外调用 fireEvent，避免重复事件。
+        super.setModelValue(newValue, fromClient);
     }
 
     @ClientCallable

--- a/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
+++ b/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
@@ -197,6 +197,96 @@ class VaadinCKEditorIntegrationTest {
             assertTrue(sanitized.contains("Text"));
             assertFalse(sanitized.contains("<script>"));
         }
+
+        @Test
+        @DisplayName("issue #85: ValueChangeListener should receive new value via getValue() on client change")
+        void testValueChangeListenerReceivesNewValueFromClient() {
+            // 回归测试 issue #85：客户端输入触发 setModelValue 时，
+            // 监听器内调用 event.getValue() 必须返回新内容而非旧内容。
+            AtomicReference<String> capturedValue = new AtomicReference<>();
+            editor.addValueChangeListener(event ->
+                capturedValue.set(event.getValue()));
+
+            // 模拟来自客户端的内容变更（@ClientCallable setEditorData 走的就是这条路径）
+            editor.setModelValue("<p>typed by user</p>", true);
+
+            // issue #85 的核心断言：监听器读到的必须是新内容，而非旧内容。
+            assertEquals("<p>typed by user</p>", capturedValue.get(),
+                "event.getValue() should return the new content, not the stale value");
+            // getValue() 在事件之外也应保持一致
+            assertEquals("<p>typed by user</p>", editor.getValue());
+        }
+
+        @Test
+        @DisplayName("issue #85: ValueChangeListener should receive new value via getValue() on setValue")
+        void testValueChangeListenerReceivesNewValueFromSetValue() {
+            // 服务端 setValue 路径同样必须保证监听器读到新值。
+            AtomicReference<String> capturedValue = new AtomicReference<>();
+            editor.addValueChangeListener(event -> capturedValue.set(event.getValue()));
+
+            editor.setValue("<p>set by server</p>");
+
+            assertEquals("<p>set by server</p>", capturedValue.get(),
+                "event.getValue() should return the new content on the setValue path");
+            assertEquals("<p>set by server</p>", editor.getValue());
+        }
+
+        @Test
+        @DisplayName("setModelValue should not fire event when value is unchanged")
+        void testSetModelValueNoEventOnUnchanged() {
+            editor.setValue("<p>same</p>");
+
+            AtomicInteger fireCount = new AtomicInteger(0);
+            editor.addValueChangeListener(event -> fireCount.incrementAndGet());
+
+            // 设置相同的值不应触发事件
+            editor.setModelValue("<p>same</p>", true);
+            assertEquals(0, fireCount.get(), "no event should fire when value is unchanged");
+
+            // 设置不同的值应触发一次事件
+            editor.setModelValue("<p>different</p>", true);
+            assertEquals(1, fireCount.get(), "exactly one event should fire on actual change");
+        }
+
+        @Test
+        @DisplayName("issue #85: setValue(null) listener value must match final getValue()")
+        void testSetValueNullListenerConsistency() {
+            // P1 边界（审查发现）：setValue(null) 时，事件内读到的值
+            // 必须与方法返回后 getValue() 保持一致，均为 ""，不得为 null。
+            editor.setValue("<p>existing</p>");
+
+            AtomicReference<String> capturedValue = new AtomicReference<>("SENTINEL");
+            editor.addValueChangeListener(event -> capturedValue.set(event.getValue()));
+
+            editor.setValue(null);
+
+            assertEquals("", capturedValue.get(),
+                "event.getValue() must be normalized to empty string, not null");
+            assertEquals("", editor.getValue(),
+                "getValue() must return empty string after setValue(null)");
+        }
+
+        @Test
+        @DisplayName("issue #85: consecutive client changes carry correct old/new values")
+        void testConsecutiveClientChangesOldNewValues() {
+            // 验证 oldValue/newValue 语义在连续变更下正确传递。
+            AtomicReference<String> lastOld = new AtomicReference<>();
+            AtomicReference<String> lastNew = new AtomicReference<>();
+            editor.addValueChangeListener(event -> {
+                lastOld.set(event.getOldValue());
+                lastNew.set(event.getValue());
+            });
+
+            editor.setModelValue("<p>first</p>", true);
+            assertEquals("<p>first</p>", lastNew.get());
+
+            editor.setModelValue("<p>second</p>", true);
+            // 第二次变更：旧值应为第一次的新值，新值应为第二次内容。
+            assertEquals("<p>first</p>", lastOld.get(),
+                "oldValue should carry the previous content on consecutive changes");
+            assertEquals("<p>second</p>", lastNew.get());
+            assertEquals("<p>second</p>", editor.getValue());
+        }
     }
 
     // ==================== Content Stats Tests ====================


### PR DESCRIPTION
## Summary

Fixes #85 — `ValueChangeEvent.getValue()` returned the **previous** editor content instead of the newly entered text.

`VaadinCKEditor` overrides `getValue()` to return its internal `editorData` field. Vaadin's `ComponentValueChangeEvent` constructor reads the value eagerly (`this.value = hasValue.getValue()`), so when `editorData` was assigned **after** `super.setModelValue`/`setValue` fired the event, listeners observed stale content.

This was especially damaging for **`Binder`-bound forms**: `Binder` reads the field value on every change via the `HasValue`/`ValueChangeEvent` contract, so the bug silently corrupted bean values.

## Fix

Both value paths now ensure `editorData` is current **before** the event fires:

- **`setModelValue` (client path):** assign `editorData` before the `super` call — the core #85 fix.
- **`setValue` (server path):** normalize `null → ""` before `super.setValue`, preventing the event from observing `null` while `getValue()` later returns `""` (adjacent edge case surfaced during review).

No public API change. No double-event or swallowed-event regression: Vaadin computes `oldValue` and the equality short-circuit from its internal `bufferedValue`, which is independent of `editorData`.

## Tests

Added 5 regression tests in `VaadinCKEditorIntegrationTest`:

1. Client path — listener receives new value via `getValue()` (direct #85 repro)
2. Server `setValue` path — listener receives new value
3. No event fired when value is unchanged (short-circuit guard)
4. `setValue(null)` — event value and final `getValue()` are consistent (both `""`, never `null`)
5. Consecutive client changes carry correct old/new values

Each fix was verified to **fail before** the change and **pass after**. Full suite: **493 tests, 0 failures**.

## Notes

- `ContentChangeEvent` is unaffected (it carries explicit client-side snapshots, never reads `getValue()`) and is intentionally left untouched.
- `ContentChangeEvent` is **not** a substitute for `Binder` — `Binder` is hard-coupled to the `HasValue`/`ValueChangeEvent` contract, so this `ValueChangeEvent` fix is the correct resolution for form binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)