### PR TITLE
chore(deps): upgrade Vaadin Platform 25.1.6 → 25.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Vaadin Platform: 25.1.6 → 25.2.0 (root addon `pom.xml` + `examples/spring-boot-sample/pom.xml`)
+  - Companion `provided` dependencies verified against 25.2.0's `flow-server` BOM and kept unchanged
+    (no conflict): `jackson-databind`/`jackson-core` 3.1.3, `jakarta.servlet-api` 6.1.0 — these match the
+    versions Vaadin 25.2.0 itself manages, so no bump is needed.
+
 ## [5.2.0] - 2026-05-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ implementation("com.wontlost:ckeditor-vaadin:5.1.0")
 
 | 依赖 | 版本 | 备注 |
 |---|---|---|
-| Vaadin Platform | 25.1.6+ | 25.x 系列；前向兼容 25.2-SNAPSHOT |
+| Vaadin Platform | 25.2.0+ | 25.x 系列 |
 | CKEditor 5 (`ckeditor5`) | 48.1.1 | npm 精确版本 |
 | `ckeditor5-premium-features` | 48.1.1 | 与 `ckeditor5` 必须同版本 |
 | Java | 21+ | Vaadin 25 baseline |
 | Jackson (`tools.jackson.core`) | 3.1.3+ | 由消费端提供 |
-| Jakarta Servlet API | 6.1.0+ | Vaadin 25.1 支持矩阵 |
+| Jakarta Servlet API | 6.1.0+ | Vaadin 25.2 支持矩阵 |
 | Spring Boot | 4.0.4+ | 推荐（匹配 Jackson 3.1） |
 
 > Unreleased 版本将 CKEditor 47 → 48 的配置兼容层下沉到前端 normalizer；旧顶层 `initialData`/`placeholder`/`label` 与 v47 AI 配置自动迁移到 v48 字段。详见 [CHANGELOG](CHANGELOG.md)。

--- a/examples/spring-boot-sample/pom.xml
+++ b/examples/spring-boot-sample/pom.xml
@@ -16,12 +16,12 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Vaadin CKEditor Sample (E2E)</name>
-    <description>Minimal Spring Boot 4 + Vaadin 25.1.6 sample app driving the addon for Playwright E2E tests. NOT published.</description>
+    <description>Minimal Spring Boot 4 + Vaadin 25.2.0 sample app driving the addon for Playwright E2E tests. NOT published.</description>
 
     <properties>
         <java.version>21</java.version>
         <maven.compiler.release>21</maven.compiler.release>
-        <vaadin.version>25.1.6</vaadin.version>
+        <vaadin.version>25.2.0</vaadin.version>
         <!-- Keep in sync with the root pom's <version>. Pinned so the sample exercises a
              specific addon build; bump together when the addon version changes. -->
         <addon.version>5.2.0</addon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <developerConnection>scm:git:git@github.com:wontlost-ltd/vaadin-ckeditor.git</developerConnection>
     </scm>
     <properties>
-        <vaadin.version>25.1.6</vaadin.version>
+        <vaadin.version>25.2.0</vaadin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Summary

Upgrade the Vaadin Platform from **25.1.6** to **25.2.0** (latest stable 25.x GA on Maven Central) across the addon and the E2E sample app, plus a health-check of the companion dependencies.

Closes #87

## Changes

| File | Change |
|---|---|
| `pom.xml` | `vaadin.version` 25.1.6 → **25.2.0** |
| `examples/spring-boot-sample/pom.xml` | `vaadin.version` + description → **25.2.0** |
| `README.md` | Compatibility matrix → Vaadin 25.2.0+ |
| `CHANGELOG.md` | `[Unreleased]` records the bump + health-check finding |

## Companion dependency health-check

Compared this project's manually-pinned `provided` deps against `flow-server-25.2.0`'s BOM. They **already match** what Vaadin 25.2.0 manages — no bump needed, no conflict:

- `jackson-databind` / `jackson-core` → **3.1.3** (= our pin)
- `jakarta.servlet-api` → **6.1.0** (= our pin)

> Note: Jackson 3.2.0 exists, but bumping would *diverge* from the version Vaadin 25.2.0 anchors, so we intentionally stay at 3.1.3. JUnit (6.0.3, test scope) is platform-independent.

## Verification

```
mvn -B clean test       → Tests run: 488, Failures: 0, Errors: 0 — BUILD SUCCESS
mvn -B dependency:tree  → Vaadin 25.2.0 resolves cleanly, no version conflict
```

No source/API changes required by the platform bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)