### PR TITLE
chore: post-upgrade cleanup — sync CKEditor @NpmPackage version + reduce nesting

### DIFF
--- a/examples/spring-boot-sample/pom.xml
+++ b/examples/spring-boot-sample/pom.xml
@@ -24,7 +24,7 @@
         <vaadin.version>25.2.0</vaadin.version>
         <!-- Keep in sync with the root pom's <version>. Pinned so the sample exercises a
              specific addon build; bump together when the addon version changes. -->
-        <addon.version>5.2.0</addon.version>
+        <addon.version>5.3.0</addon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.wontlost</groupId>
     <artifactId>ckeditor-vaadin</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.0</version>
+    <version>5.3.0</version>
     <name>CKEditorVaadin</name>
     <description>Integration of CKEditor 5 for Vaadin</description>
     <url>https://github.com/wontlost-ltd/vaadin-ckeditor</url>

--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -90,7 +90,7 @@ import static com.wontlost.ckeditor.JsonUtil.*;
  */
 @Tag("vaadin-ckeditor")
 @JsModule("./vaadin-ckeditor/vaadin-ckeditor.ts")
-@NpmPackage(value = "ckeditor5", version = "48.1.1")
+@NpmPackage(value = "ckeditor5", version = "48.2.0")
 @NpmPackage(value = "lit", version = "^3.3.2")
 public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel {
 

--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -91,12 +91,12 @@ import static com.wontlost.ckeditor.JsonUtil.*;
 @Tag("vaadin-ckeditor")
 @JsModule("./vaadin-ckeditor/vaadin-ckeditor.ts")
 @NpmPackage(value = "ckeditor5", version = "48.2.0")
-@NpmPackage(value = "lit", version = "^3.3.2")
+@NpmPackage(value = "lit", version = "^3.3.3")
 public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel {
 
     private static final Logger logger = Logger.getLogger(VaadinCKEditor.class.getName());
     /** Keep in sync with version field in vaadin-ckeditor.ts */
-    private static final String VERSION = "5.1.0";
+    private static final String VERSION = "5.3.0";
 
     /**
      * Default autosave waiting time in milliseconds.

--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditorPremium.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditorPremium.java
@@ -79,7 +79,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * @see CustomPlugin#fromPremium(String)
  * @since 5.0.0
  */
-@NpmPackage(value = "ckeditor5-premium-features", version = "48.1.1")
+@NpmPackage(value = "ckeditor5-premium-features", version = "48.2.0")
 public final class VaadinCKEditorPremium {
 
     private static volatile boolean enabled = false;
@@ -148,7 +148,7 @@ public final class VaadinCKEditorPremium {
      * @return the npm package version
      */
     public static String getVersion() {
-        return "48.1.1";
+        return "48.2.0";
     }
 
     /**

--- a/src/main/java/com/wontlost/ckeditor/internal/UploadManager.java
+++ b/src/main/java/com/wontlost/ckeditor/internal/UploadManager.java
@@ -235,63 +235,78 @@ public class UploadManager {
         timedFuture.handle((result, ex) -> {
             // Synchronize task state updates
             synchronized (task) {
-                // Double notification guard: if already notified or cancelled, return immediately
-                if (task.isNotified()) {
-                    logger.log(Level.FINE, "Upload {0} already notified, skipping duplicate callback", uploadId);
-                    activeTasks.remove(uploadId);
-                    return null;
-                }
-
-                if (task.getStatus() == UploadStatus.CANCELLED) {
-                    // Task was cancelled, ignore result
-                    logger.log(Level.FINE, "Upload {0} was cancelled, ignoring result", uploadId);
-                    activeTasks.remove(uploadId);
-                    return null;
-                }
-
-                long elapsedMs = task.getElapsedTimeMs();
-
-                if (ex != null) {
-                    // Exception handling - unwrap CompletionException to get root cause
-                    Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
-                        ? ex.getCause() : ex;
-                    task.setStatus(UploadStatus.FAILED);
-                    String errorMsg;
-                    if (cause instanceof TimeoutException) {
-                        errorMsg = "Upload timed out after " + uploadTimeoutSeconds + " seconds";
-                        logger.log(Level.WARNING, "Upload {0} timed out after {1}ms", new Object[]{uploadId, elapsedMs});
-                    } else {
-                        errorMsg = cause.getMessage();
-                        if (errorMsg == null || errorMsg.isEmpty()) {
-                            errorMsg = cause.getClass().getSimpleName() + " occurred during upload";
-                        }
-                        logger.log(Level.WARNING, "Upload {0} failed after {1}ms: {2}",
-                            new Object[]{uploadId, elapsedMs, errorMsg});
-                    }
-                    task.setErrorMessage(errorMsg);
-                    notifyResult(uploadId, task, null, errorMsg);
-                } else if (result != null && result.isSuccess()) {
-                    // Success
-                    task.setStatus(UploadStatus.COMPLETED);
-                    task.setResultUrl(result.getUrl());
-                    logger.log(Level.INFO, "Upload {0} completed successfully in {1}ms, url={2}",
-                        new Object[]{uploadId, elapsedMs, result.getUrl()});
-                    notifyResult(uploadId, task, result.getUrl(), null);
-                } else {
-                    // Failure
-                    task.setStatus(UploadStatus.FAILED);
-                    String errorMsg = result != null ? result.getErrorMessage() : "Unknown upload error";
-                    task.setErrorMessage(errorMsg);
-                    logger.log(Level.WARNING, "Upload {0} failed after {1}ms: {2}",
-                        new Object[]{uploadId, elapsedMs, errorMsg});
-                    notifyResult(uploadId, task, null, errorMsg);
-                }
-
-                // Clean up completed task
-                activeTasks.remove(uploadId);
+                processCompletion(uploadId, task, result, ex);
             }
             return null;
         });
+    }
+
+    /**
+     * 处理上传 Future 完成后的状态更新与回调通知（在 task 锁内调用）。
+     *
+     * 通过卫语句提前返回，将原本嵌套的成功/失败/重复分支拍平为单层分发。
+     */
+    private void processCompletion(String uploadId, UploadTask task,
+                                   UploadHandler.UploadResult result, Throwable ex) {
+        // 重复通知防护：已通知或已取消时直接返回
+        if (task.isNotified()) {
+            logger.log(Level.FINE, "Upload {0} already notified, skipping duplicate callback", uploadId);
+            activeTasks.remove(uploadId);
+            return;
+        }
+
+        if (task.getStatus() == UploadStatus.CANCELLED) {
+            logger.log(Level.FINE, "Upload {0} was cancelled, ignoring result", uploadId);
+            activeTasks.remove(uploadId);
+            return;
+        }
+
+        long elapsedMs = task.getElapsedTimeMs();
+
+        if (ex != null) {
+            String errorMsg = resolveFailureMessage(uploadId, ex, elapsedMs);
+            task.setStatus(UploadStatus.FAILED);
+            task.setErrorMessage(errorMsg);
+            notifyResult(uploadId, task, null, errorMsg);
+        } else if (result != null && result.isSuccess()) {
+            task.setStatus(UploadStatus.COMPLETED);
+            task.setResultUrl(result.getUrl());
+            logger.log(Level.INFO, "Upload {0} completed successfully in {1}ms, url={2}",
+                new Object[]{uploadId, elapsedMs, result.getUrl()});
+            notifyResult(uploadId, task, result.getUrl(), null);
+        } else {
+            String errorMsg = result != null ? result.getErrorMessage() : "Unknown upload error";
+            task.setStatus(UploadStatus.FAILED);
+            task.setErrorMessage(errorMsg);
+            logger.log(Level.WARNING, "Upload {0} failed after {1}ms: {2}",
+                new Object[]{uploadId, elapsedMs, errorMsg});
+            notifyResult(uploadId, task, null, errorMsg);
+        }
+
+        // 清理已完成的任务
+        activeTasks.remove(uploadId);
+    }
+
+    /**
+     * 从异常推导失败信息并记录日志。
+     * 解包 CompletionException 取根因；TimeoutException 给出超时文案，其余回退到异常消息或类名。
+     */
+    private String resolveFailureMessage(String uploadId, Throwable ex, long elapsedMs) {
+        Throwable cause = (ex instanceof CompletionException && ex.getCause() != null)
+            ? ex.getCause() : ex;
+
+        if (cause instanceof TimeoutException) {
+            logger.log(Level.WARNING, "Upload {0} timed out after {1}ms", new Object[]{uploadId, elapsedMs});
+            return "Upload timed out after " + uploadTimeoutSeconds + " seconds";
+        }
+
+        String errorMsg = cause.getMessage();
+        if (errorMsg == null || errorMsg.isEmpty()) {
+            errorMsg = cause.getClass().getSimpleName() + " occurred during upload";
+        }
+        logger.log(Level.WARNING, "Upload {0} failed after {1}ms: {2}",
+            new Object[]{uploadId, elapsedMs, errorMsg});
+        return errorMsg;
     }
 
     /**

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/package-lock.json
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "vaadin-ckeditor",
-  "version": "5.1.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaadin-ckeditor",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "dependencies": {
         "ckeditor5": "48.2.0",
-        "lit": "^3.3.2"
+        "lit": "^3.3.3"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.9",
@@ -1022,6 +1022,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1045,31 +1046,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1248,9 +1227,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1268,9 +1244,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,9 +1261,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1308,9 +1278,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1295,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,9 +1312,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1552,6 +1513,7 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -2484,6 +2446,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2661,9 +2624,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2685,9 +2645,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2709,9 +2666,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2733,9 +2687,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2792,9 +2743,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -3753,6 +3704,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4375,6 +4327,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4453,6 +4406,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/package.json
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-ckeditor",
-  "version": "5.1.0",
+  "version": "5.3.0",
   "description": "Vaadin CKEditor 5 Web Component",
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "ckeditor5": "48.2.0",
-    "lit": "^3.3.2"
+    "lit": "^3.3.3"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.9",

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -316,7 +316,7 @@ export class VaadinCKEditor extends LitElement {
     private $server?: VaadinServer;
 
     // Version info — keep in sync with VaadinCKEditor.java VERSION constant
-    private readonly version = '5.1.0';
+    private readonly version = '5.3.0';
 
     constructor() {
         super();

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -1667,34 +1667,27 @@ export class VaadinCKEditor extends LitElement {
                 this.cursorPosition = null;
 
                 // Step 2: Remove all event listeners BEFORE destroy
-                // Use try-catch for each to ensure all get attempted
-                try {
-                    if (this.selectionChangeListener) {
-                        editor.model.document.selection.off('change:range', this.selectionChangeListener);
-                    }
-                } catch (e) { /* ignore */ }
+                // 每个 off() 独立 try，确保任一失败不影响后续清理
+                const safeOff = (remove: () => void): void => {
+                    try { remove(); } catch { /* ignore */ }
+                };
 
-                try {
-                    if (this.dataChangeListener) {
-                        editor.model.document.off('change:data', this.dataChangeListener);
-                    }
-                } catch (e) { /* ignore */ }
-
-                try {
-                    if (this.focusChangeListener) {
-                        editor.editing.view.document.off('change:isFocused', this.focusChangeListener);
-                    }
-                } catch (e) { /* ignore */ }
-
-                try {
-                    if (this.readOnlyChangeListener) {
-                        editor.off('change:isReadOnly', this.readOnlyChangeListener);
-                    }
-                } catch (e) { /* ignore */ }
+                if (this.selectionChangeListener) {
+                    safeOff(() => editor.model.document.selection.off('change:range', this.selectionChangeListener!));
+                }
+                if (this.dataChangeListener) {
+                    safeOff(() => editor.model.document.off('change:data', this.dataChangeListener!));
+                }
+                if (this.focusChangeListener) {
+                    safeOff(() => editor.editing.view.document.off('change:isFocused', this.focusChangeListener!));
+                }
+                if (this.readOnlyChangeListener) {
+                    safeOff(() => editor.off('change:isReadOnly', this.readOnlyChangeListener!));
+                }
 
                 // Remove undo/redo/clipboard/collaboration listeners
                 for (const cleanup of this.listenerCleanups) {
-                    try { cleanup(); } catch { /* ignore */ }
+                    safeOff(cleanup);
                 }
                 this.listenerCleanups = [];
 


### PR DESCRIPTION
## Summary

Follow-up to the recent dependency upgrades, in two commits:

1. **Post-upgrade audit fixes** — one real version-drift bug + two quality improvements
2. **Version bump to 5.3.0** + lit 3.3.3 (per maintainer request)

## Commit 1 — audit fixes

### 🔴 CKEditor version drift
PR #90 bumped the frontend `package.json` to `ckeditor5@48.2.0`, but the **Java `@NpmPackage` annotations** (what tells consuming apps which npm version to install) were left at `48.1.1`.

| File | Before | After |
|---|---|---|
| `VaadinCKEditor.java` | `@NpmPackage ckeditor5 48.1.1` | **48.2.0** |
| `VaadinCKEditorPremium.java` | `@NpmPackage premium 48.1.1` + `getVersion()` | **48.2.0** |

### 🟡 Quality improvements
- `UploadManager.java`: 5-level-nested `handle()` lambda → `processCompletion()` + `resolveFailureMessage()` with guard clauses (≤3 levels)
- `vaadin-ckeditor.ts`: 4 duplicated `try/catch` listener-off blocks → single `safeOff()` helper

### ✅ Verified-clean (no change)
`setPropertyJson` / `CustomField` / `@JsModule` / `@NpmPackage` confirmed NOT `@Deprecated` in `flow-server-25.2.0.jar` (`javap -v`). The 47→48 config normalizer kept — it's a user-facing back-compat layer, not dead code.

## Commit 2 — version 5.3.0 + lit 3.3.3

Addon version → **5.3.0**, synced across all five references that must stay in lockstep:
- `pom.xml` `<version>`, `examples/spring-boot-sample/pom.xml` `addon.version`
- `VaadinCKEditor.java` `VERSION` (was stale at 5.1.0), `vaadin-ckeditor.ts` `version`, `package.json` `version`

`lit` `^3.3.2 → ^3.3.3` (package.json + Java `@NpmPackage`; lockfile regenerated).

## Verification

```
mvn -B clean test    → 493/493, BUILD SUCCESS
npm run typecheck    → clean (exit 0)
npm test (vitest)    → 114/114
npm audit            → 0 vulnerabilities
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)