### PR TITLE
docs: finalize CHANGELOG + README for 5.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-06-26
+
 ### Changed
 - Vaadin Platform: 25.1.6 → 25.2.0 (root addon `pom.xml` + `examples/spring-boot-sample/pom.xml`)
-  - Companion `provided` dependencies verified against 25.2.0's `flow-server` BOM and kept unchanged
-    (no conflict): `jackson-databind`/`jackson-core` 3.1.3, `jakarta.servlet-api` 6.1.0 — these match the
-    versions Vaadin 25.2.0 itself manages, so no bump is needed.
+  - Companion `provided` dependencies verified against 25.2.0's `flow-server` BOM
+    (`jakarta.servlet-api` 6.1.0 matches and is kept).
 - CKEditor 5 (`ckeditor5`, `ckeditor5-premium-features`): 48.1.1 → 48.2.0
-  - `package-lock.json` regenerated via `npm install` (resolves `ckeditor5@48.2.0`)
-  - `tsc --noEmit` clean — no premium AI `.d.ts` type-contract drift; no source changes required
-  - Frontend vitest suite 114/114 green against 48.2.0
+  - `package-lock.json` regenerated; `tsc --noEmit` clean — no premium AI `.d.ts`
+    type-contract drift; no source changes required; frontend vitest 114/114 green
+  - `@NpmPackage` annotations on `VaadinCKEditor`/`VaadinCKEditorPremium` and
+    `VaadinCKEditorPremium.getVersion()` synced to 48.2.0 (these tell consuming
+    apps which npm version to install)
+- Jackson databind (`tools.jackson.core`): 3.1.3 → 3.1.4
+- `lit`: ^3.3.2 → ^3.3.3 (`package.json` + `@NpmPackage` annotation)
+- Frontend test tooling: `vitest` 3.2.4 → 4.1.9, `@vitest/coverage-v8` → ^4.1.9
+  (clears the dev-only vitest CVEs — `npm audit` now reports 0 vulnerabilities;
+  `vi.fn()` spy types adjusted for vitest 4's stricter `Mock` typing)
+- Addon version bumped to 5.3.0 and synced across all version references
+  (`pom.xml`, sample `addon.version`, Java `VERSION`, `vaadin-ckeditor.ts` version,
+  frontend `package.json`)
+
+### Fixed
+- `UploadManager` completion handler refactored: the upload `handle()` lambda
+  (previously 5 indent levels) extracted into `processCompletion()` +
+  `resolveFailureMessage()` with guard clauses (now ≤3 levels), removing
+  duplicated failure-message logic
+- `vaadin-ckeditor.ts`: collapsed 4 duplicated `try/catch` listener-removal blocks
+  into a single `safeOff()` helper
 
 ## [5.2.0] - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ A comprehensive CKEditor 5 integration for Vaadin 24+.
 <dependency>
     <groupId>com.wontlost</groupId>
     <artifactId>ckeditor-vaadin</artifactId>
-    <version>5.1.0</version>
+    <version>5.3.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("com.wontlost:ckeditor-vaadin:5.1.0")
+implementation("com.wontlost:ckeditor-vaadin:5.3.0")
 ```
 
 ### Compatibility Matrix


### PR DESCRIPTION
## Summary

Release-prep for **5.3.0**: finalize the CHANGELOG and bump the README install snippets. No code changes — all functional work for 5.3.0 already landed in earlier PRs (#86, #88, #90, #91, #84, #92).

## Changes

- **CHANGELOG.md**: `[Unreleased]` → `[5.3.0] - 2026-06-26`, with the complete change set for this release:
  - Vaadin 25.1.6 → 25.2.0
  - CKEditor 48.1.1 → 48.2.0 (+ `@NpmPackage` version sync)
  - jackson-databind 3.1.3 → 3.1.4
  - lit ^3.3.2 → ^3.3.3
  - vitest 3.2.4 → 4.1.9 (clears dev-only CVEs; npm audit 0 vulns)
  - UploadManager / listener-cleanup refactors
- **README.md**: Maven + Gradle install version `5.1.0` → `5.3.0`

## Verification

```
mvn -B clean package → 493/493 tests, builds ckeditor-vaadin-5.3.0.jar, BUILD SUCCESS
```

After merge, releasing is triggered by pushing the `v5.3.0` tag (publish.yml deploys to Maven Central + creates the GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)