### PR TITLE
fix: insertText works when editor is empty or cursor unmoved (#69)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -1597,11 +1597,20 @@ export class VaadinCKEditor extends LitElement {
      * Public API: Insert text at cursor position
      */
     public insertText(text: string): void {
-        if (this.editor && this.cursorPosition) {
-            this.editor.model.change(writer => {
-                this.editor!.model.insertContent(writer.createText(text), this.cursorPosition as Parameters<typeof this.editor.model.insertContent>[1]);
-            });
+        if (!this.editor) {
+            return;
         }
+        // cursorPosition 仅在 change:range 事件触发后才有值；编辑器为空或首次插入
+        // （光标在首字符前、尚未发生选区变化）时它仍为 null。回退到当前选区的首位置，
+        // 确保 insertText 在这些场景下也能工作（issue #69）。
+        const position = this.cursorPosition
+            ?? this.editor.model.document.selection.getFirstPosition();
+        if (!position) {
+            return;
+        }
+        this.editor.model.change(writer => {
+            this.editor!.model.insertContent(writer.createText(text), position as Parameters<typeof this.editor.model.insertContent>[1]);
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #69 — `insertText()` did nothing when the editor was empty or the cursor hadn't been moved yet.

## Root cause

`insertText()` guarded on `this.cursorPosition`, which is only assigned inside the `change:range` selection listener. In a fresh/empty editor (or before any caret movement), `cursorPosition` is still `null`, so the guard `if (this.editor && this.cursorPosition)` was false and the method silently returned.

## Fix

Fall back to `editor.model.document.selection.getFirstPosition()` when `cursorPosition` is null:

```ts
const position = this.cursorPosition
    ?? this.editor.model.document.selection.getFirstPosition();
```

## Verification

```
tsc --noEmit  → clean
vitest        → 114/114
```

Component runtime behavior is covered by the e2e suite (this project's unit tests cover pure modules only — there is no in-process `VaadinCKEditor` harness to mock the full CKEditor model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)