### PR TITLE
fix: reflect read-only state as attribute/class on host (#44)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -1427,6 +1427,11 @@ export class VaadinCKEditor extends LitElement {
      * Update read-only state
      */
     private updateReadOnly(): void {
+        // 在宿主元素上反映只读状态，便于外部 CSS 通过 vaadin-ckeditor[readonly]
+        // 或 .readonly 选择器定制只读外观（issue #44）。即使 editor 尚未就绪也先反映。
+        this.toggleAttribute('readonly', this.isReadOnly);
+        this.classList.toggle('readonly', this.isReadOnly);
+
         if (!this.editor) return;
 
         if (this.isReadOnly) {


### PR DESCRIPTION
## Summary

Fixes #44 — there was no CSS hook on the `<vaadin-ckeditor>` element to style read-only state.

## Root cause

`updateReadOnly()` only called `editor.enableReadOnlyMode()`, which applies `ck-read-only` to an *inner* CKEditor div. The host element got no indicator, so consumers couldn't write `vaadin-ckeditor[readonly] { ... }`.

## Fix

`updateReadOnly()` now also reflects the state on the host:

```ts
this.toggleAttribute('readonly', this.isReadOnly);
this.classList.toggle('readonly', this.isReadOnly);
```

Consumers can now target `vaadin-ckeditor[readonly]` / `vaadin-ckeditor.readonly`. Purely additive — no behavioral change.

## Verification

```
tsc --noEmit → clean
vitest       → 114/114
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)