### PR TITLE
fix: sync enabled state to the editor frontend (#46)

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -394,6 +394,21 @@ public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel 
         return readOnly;
     }
 
+    /**
+     * 同步 enabled 状态到前端（issue #46）。
+     *
+     * <p>沿用 Vaadin 推荐的 {@link com.vaadin.flow.component.Component#onEnabledStateChanged(boolean)}
+     * 钩子，而非覆写 {@code setEnabled}——Vaadin 自身负责 disabled 属性的传播，这里只把状态
+     * 推给 CKEditor 前端，使禁用时编辑器不可交互（CKEditor 5 通过只读锁实现禁用）。</p>
+     */
+    @Override
+    public void onEnabledStateChanged(boolean enabled) {
+        super.onEnabledStateChanged(enabled);
+        getElement().setProperty("isEnabled", enabled);
+        getId().ifPresent(id ->
+            getElement().executeJs("this.isEnabled = $0", enabled));
+    }
+
     @Override
     public void setWidth(String width) {
         super.setWidth(width);

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -186,6 +186,7 @@ export class VaadinCKEditor extends LitElement {
     @property({ type: String }) language = 'en';
     @property({ type: String }) overrideCssUrl = '';
     @property({ type: Boolean }) isReadOnly = false;
+    @property({ type: Boolean }) isEnabled = true;
     @property({ type: Boolean }) autosave = false;
     @property({ type: Number }) autosaveWaitingTime = 2000;
     @property({ type: Boolean }) minimapEnabled = false;
@@ -372,6 +373,10 @@ export class VaadinCKEditor extends LitElement {
 
         if (changedProperties.has('isReadOnly') && this.editor) {
             this.updateReadOnly();
+        }
+
+        if (changedProperties.has('isEnabled') && this.editor) {
+            this.updateEnabled();
         }
 
         if (changedProperties.has('hideToolbar') && this.editor) {
@@ -918,6 +923,9 @@ export class VaadinCKEditor extends LitElement {
         // Set read-only state
         this.updateReadOnly();
 
+        // Set enabled state (issue #46)
+        this.updateEnabled();
+
         // Set toolbar visibility
         this.updateToolbarVisibility();
 
@@ -1433,6 +1441,25 @@ export class VaadinCKEditor extends LitElement {
             this.editor.enableReadOnlyMode(this.editorId);
         } else {
             this.editor.disableReadOnlyMode(this.editorId);
+        }
+    }
+
+    /**
+     * 同步 enabled 状态（issue #46）。CKEditor 5 无独立的 disabled 概念，
+     * 用一个区别于 editorId 的只读锁实现 disable，避免与用户显式的 readOnly 互相覆盖；
+     * 同时在宿主元素上反映 disabled 属性/类，便于外部 CSS 定制。
+     */
+    private updateEnabled(): void {
+        this.toggleAttribute('disabled', !this.isEnabled);
+        this.classList.toggle('disabled', !this.isEnabled);
+
+        if (!this.editor) return;
+
+        const disabledLockId = `${this.editorId}--disabled`;
+        if (this.isEnabled) {
+            this.editor.disableReadOnlyMode(disabledLockId);
+        } else {
+            this.editor.enableReadOnlyMode(disabledLockId);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #46 — `setEnabled(false)` updated Vaadin's backend state but the CKEditor frontend stayed interactive.

## Fix

- **Backend** (`VaadinCKEditor.java`): override `Component.onEnabledStateChanged(boolean)` — Vaadin's recommended hook (Vaadin itself handles the `disabled` attribute) — to push an `isEnabled` property to the frontend.
- **Frontend** (`vaadin-ckeditor.ts`): new `isEnabled` `@property` + `updated()`/init handler. `updateEnabled()` disables the editor via a read-only lock keyed `${editorId}--disabled`, **distinct** from the user's explicit read-only lock so the two are independent. Also reflects a `disabled` attribute/class on the host for CSS.

## Why `onEnabledStateChanged` (not `setEnabled` override)

`setEnabled` is a default interface method; Vaadin manages the disabled-attribute propagation itself and exposes `onEnabledStateChanged` as the official reaction hook. Overriding that is the idiomatic, non-fragile approach.

## Verification

```
mvn -B clean test → 493/493, BUILD SUCCESS
tsc --noEmit      → clean
vitest            → 114/114
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)