### PR TITLE
fix: don't round-trip server-originated data changes — Binder.hasChanges (#38)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/data-change-decision.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/data-change-decision.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { decideDataChange, type DataChangeState } from './data-change-decision';
+
+function state(overrides: Partial<DataChangeState> = {}): DataChangeState {
+    return {
+        newContent: '<p>new</p>',
+        lastKnownContent: '<p>old</p>',
+        sync: true,
+        apiChangeDepth: 0,
+        changeSource: 'USER_INPUT',
+        ...overrides,
+    };
+}
+
+describe('decideDataChange', () => {
+    describe('issue #38: server-originated changes must not round-trip to the server', () => {
+        it('does NOT sync to server when apiChangeDepth > 0 (Binder.readBean echo)', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 1, sync: true }));
+            expect(d.syncToServer).toBe(false);
+        });
+
+        it('still syncs to server for genuine user input (apiChangeDepth === 0)', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 0, sync: true }));
+            expect(d.syncToServer).toBe(true);
+        });
+
+        it('labels content-change source as API when server-originated', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 1, changeSource: 'USER_INPUT' }));
+            expect(d.contentChangeSource).toBe('API');
+        });
+
+        it('nested API changes (apiChangeDepth > 1) are still treated as API-originated', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 2 }));
+            expect(d.syncToServer).toBe(false);
+            expect(d.contentChangeSource).toBe('API');
+        });
+    });
+
+    describe('sync flag', () => {
+        it('does not sync to server when sync is false, even for user input', () => {
+            const d = decideDataChange(state({ sync: false, apiChangeDepth: 0 }));
+            expect(d.syncToServer).toBe(false);
+        });
+
+        it('syncs to server when sync is true and change is user-originated', () => {
+            const d = decideDataChange(state({ sync: true, apiChangeDepth: 0 }));
+            expect(d.syncToServer).toBe(true);
+        });
+    });
+
+    describe('content-change firing', () => {
+        it('fires content change when content actually changed', () => {
+            const d = decideDataChange(state({ newContent: '<p>a</p>', lastKnownContent: '<p>b</p>' }));
+            expect(d.fireContentChange).toBe(true);
+            expect(d.nextLastKnownContent).toBe('<p>a</p>');
+            expect(d.resetChangeSource).toBe(true);
+        });
+
+        it('does NOT fire content change when content is unchanged', () => {
+            const d = decideDataChange(state({ newContent: '<p>same</p>', lastKnownContent: '<p>same</p>' }));
+            expect(d.fireContentChange).toBe(false);
+            expect(d.nextLastKnownContent).toBeNull();
+            expect(d.resetChangeSource).toBe(false);
+        });
+    });
+
+    describe('change source labeling for user-originated changes', () => {
+        it('preserves UNDO_REDO source when not API-originated', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 0, changeSource: 'UNDO_REDO' }));
+            expect(d.contentChangeSource).toBe('UNDO_REDO');
+        });
+
+        it('preserves PASTE source when not API-originated', () => {
+            const d = decideDataChange(state({ apiChangeDepth: 0, changeSource: 'PASTE' }));
+            expect(d.contentChangeSource).toBe('PASTE');
+        });
+    });
+});

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/data-change-decision.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/data-change-decision.ts
@@ -1,0 +1,63 @@
+/**
+ * editor.model.document 的 change:data 事件处理决策（纯逻辑，便于单测）。
+ *
+ * 抽离自 vaadin-ckeditor.ts 的 dataChangeListener：根据当前内容、上次已知内容、
+ * 同步开关以及变更来源深度，决定是否触发 contentChange 事件、是否把数据回写服务端，
+ * 以及变更来源标签。把决策从 editor 实例中解耦，使其可在不实例化 CKEditor 的前提下测试。
+ */
+
+export interface DataChangeState {
+    /** editor.getData() 的最新返回值 */
+    newContent: string;
+    /** 组件记录的上次已知内容 */
+    lastKnownContent: string;
+    /** 是否启用实时同步（sync=true 时内容变更即回写服务端） */
+    sync: boolean;
+    /**
+     * API 变更深度：>0 表示当前 change:data 由服务端 updateData() 触发（而非用户输入）。
+     * 用于避免把服务端回填的数据再次以 fromClient=true 回写服务端（issue #38：
+     * Binder.readBean() 后 hasChanges() 误为 true）。
+     */
+    apiChangeDepth: number;
+    /** 用户态变更来源标签（USER_INPUT / UNDO_REDO / PASTE / COLLABORATION 等） */
+    changeSource: string;
+}
+
+export interface DataChangeDecision {
+    /** 是否触发 fireContentChange */
+    fireContentChange: boolean;
+    /** fireContentChange 使用的来源标签（fireContentChange=false 时无意义） */
+    contentChangeSource: string;
+    /** 是否调用 $server.setEditorData() 把数据回写服务端 */
+    syncToServer: boolean;
+    /** contentChange 触发后，lastKnownContent 应更新为的值（null 表示不更新） */
+    nextLastKnownContent: string | null;
+    /** 处理完后 changeSource 是否应重置为 USER_INPUT */
+    resetChangeSource: boolean;
+}
+
+/**
+ * 计算一次 change:data 事件应执行的动作。
+ *
+ * 关键修复（issue #38）：当 apiChangeDepth > 0 时，本次变更是服务端 updateData() 引发的回填，
+ * 不应再调用 setEditorData() 回写服务端——否则 Binder.readBean() 会触发一个 fromClient=true 的
+ * ValueChangeEvent，导致 Binder.hasChanges() 在没有用户改动时仍返回 true。
+ */
+export function decideDataChange(state: DataChangeState): DataChangeDecision {
+    const isApiOriginated = state.apiChangeDepth > 0;
+    const contentChanged = state.newContent !== state.lastKnownContent;
+
+    const fireContentChange = contentChanged;
+    const contentChangeSource = isApiOriginated ? 'API' : state.changeSource;
+
+    // 仅在用户态（非 API 回填）且开启同步时回写服务端，避免服务端回填的内容反向污染 Binder。
+    const syncToServer = state.sync && !isApiOriginated;
+
+    return {
+        fireContentChange,
+        contentChangeSource,
+        syncToServer,
+        nextLastKnownContent: fireContentChange ? state.newContent : null,
+        resetChangeSource: fireContentChange,
+    };
+}

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -23,6 +23,7 @@ import {
     stripInitialDataIfChannelSeeded,
     type RootConfig,
 } from './editor-config-normalizer';
+import { decideDataChange } from './data-change-decision';
 
 // 内置插件
 import CommentPermissionEnforcer from './comment-permission-enforcer';
@@ -1257,20 +1258,31 @@ export class VaadinCKEditor extends LitElement {
         // Handle data changes
         this.dataChangeListener = () => {
             const activeEditor = this.editor;
-            if (!activeEditor) return;
+            if (!activeEditor || !this.$server) return;
             const newContent = activeEditor.getData();
 
-            // Fire content change event if content actually changed
-            if (this.$server && newContent !== this.lastKnownContent) {
-                // Use tracked change source, defaulting to USER_INPUT
-                const source = this.apiChangeDepth > 0 ? 'API' : this.changeSource;
-                this.$server.fireContentChange(this.lastKnownContent, newContent, source);
-                this.lastKnownContent = newContent;
-                // Reset change source after firing event
-                this.changeSource = 'USER_INPUT';
+            const decision = decideDataChange({
+                newContent,
+                lastKnownContent: this.lastKnownContent,
+                sync: this.sync,
+                apiChangeDepth: this.apiChangeDepth,
+                changeSource: this.changeSource,
+            });
+
+            if (decision.fireContentChange) {
+                this.$server.fireContentChange(this.lastKnownContent, newContent, decision.contentChangeSource);
+                if (decision.nextLastKnownContent !== null) {
+                    this.lastKnownContent = decision.nextLastKnownContent;
+                }
+                if (decision.resetChangeSource) {
+                    this.changeSource = 'USER_INPUT';
+                }
             }
 
-            if (this.sync && this.$server) {
+            // issue #38: 服务端回填（apiChangeDepth>0）不回写服务端，
+            // 否则 Binder.readBean() 会触发 fromClient=true 的 ValueChangeEvent，
+            // 使 Binder.hasChanges() 在无用户改动时误为 true。
+            if (decision.syncToServer) {
                 this.$server.setEditorData(newContent);
             }
         };


### PR DESCRIPTION
## Summary

Fixes #38 — `Binder.hasChanges()` returned `true` after `Binder.readBean()` even with no user edit.

## Root cause

`readBean()` → server `updateData()` → `editor.setData()` → `change:data` → `dataChangeListener` **unconditionally** called `$server.setEditorData()` → Java `setModelValue(..., fromClient=true)` → `ValueChangeEvent(fromClient=true)` → Binder records a change.

The listener tracked `apiChangeDepth` (>0 during server-originated `setData`) but only used it to *label* the change source — not to gate the server round-trip.

## Fix

Extracted the decision into a pure module `data-change-decision.ts` (`decideDataChange()`), matching the project's `editor-config-normalizer.ts` pattern. When `apiChangeDepth > 0` the change is a server echo → `syncToServer = false`. Genuine user input (`apiChangeDepth === 0`) still syncs.

## Tests (regression guard)

New `data-change-decision.test.ts` — **10 tests** covering:
- #38: no server round-trip when `apiChangeDepth > 0`; still syncs for user input; nested depth; API source labeling
- existing `sync` flag, content-change firing, and USER_INPUT/UNDO_REDO/PASTE source behavior

## Verification

```
tsc --noEmit → clean
vitest       → 124/124 (was 114)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)