### PR TITLE
fix: lift CKEditor floating panels above Vaadin Dialog overlay (#56)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/sticky-toolbar.css
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/sticky-toolbar.css
@@ -47,6 +47,24 @@ vaadin-ckeditor .ck.ck-editor .ck.ck-sticky-panel {
     position: static !important;
 }
 
+/* ==================== Dialog / Overlay Stacking (issue #56) ==================== */
+/*
+ * Inside a Vaadin Dialog/overlay the editor's floating panels (dropdowns,
+ * balloon toolbars, the image-alignment menu, etc.) derive their z-index from
+ * CKEditor's --ck-z-default / --ck-z-panel (default 1 / 1000). A Vaadin overlay
+ * sits at a comparable/higher stacking level, so those panels can render BELOW
+ * the dialog content and clicks pass through to the background.
+ *
+ * Raise --ck-z-default for editors nested inside a Vaadin overlay so every
+ * CKEditor panel (which is computed from it) stacks above the dialog.
+ * The editor body itself is left untouched; only floating panels are lifted.
+ */
+vaadin-dialog-overlay vaadin-ckeditor,
+vaadin-overlay vaadin-ckeditor,
+[popover] vaadin-ckeditor {
+    --ck-z-default: 2147483000;
+}
+
 /* ==================== Dark Theme Support ==================== */
 /*
  * Supports both:


### PR DESCRIPTION
## Summary

Fixes #56 — inside a Vaadin `Dialog`, image-alignment (and other) dropdown items were visible but un-clickable; clicks passed through to the background.

## Root cause

CKEditor floating panels derive their z-index from `--ck-z-default` (1) / `--ck-z-panel` (1000). A Vaadin overlay sits at a comparable stacking level, so the panels rendered **below** the dialog content.

## Fix

Raise `--ck-z-default` for editors nested inside a Vaadin overlay:

```css
vaadin-dialog-overlay vaadin-ckeditor,
vaadin-overlay vaadin-ckeditor,
[popover] vaadin-ckeditor {
    --ck-z-default: 2147483000;
}
```

Every CKEditor panel is computed from `--ck-z-default`, so this lifts the whole floating-panel layer above the dialog. The editor body is untouched.

CSS-only, in the already-imported `sticky-toolbar.css`.

## Verification

```
tsc --noEmit → clean
vitest       → 114/114
```

⚠️ **Note**: this is a pure z-index/stacking fix — there's no unit-testable logic. The actual click-through behavior should be confirmed visually in a browser (an editor-in-Dialog e2e route would be the right regression guard to add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)