### PR TITLE
fix: anchor 'Powered By CKEditor' badge inside editor (#62)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/editor-config-normalizer.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/editor-config-normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
+    applyPoweredByPosition,
     buildCreateConfig,
     normalizeAIConfig48,
     normalizeRootConfig,
@@ -491,6 +492,7 @@ describe('buildCreateConfig', () => {
             toolbar: ['bold'],
             attachTo: editorElement,
             root: { initialData: '<p>Seed</p>' },
+            ui: { poweredBy: { position: 'inside' } },
         });
         expect((result.root as Record<string, unknown>).attachTo).toBeUndefined();
         expect((result.root as Record<string, unknown>).element).toBeUndefined();
@@ -510,6 +512,7 @@ describe('buildCreateConfig', () => {
             expect(result).toEqual({
                 toolbar: ['bold'],
                 root: { initialData: '<p>Seed</p>', element: editorElement },
+                ui: { poweredBy: { position: 'inside' } },
             });
             expect(result.attachTo).toBeUndefined();
         }
@@ -660,5 +663,37 @@ describe('stripInitialDataIfChannelSeeded', () => {
 
         expect(config.initialData).toBe('<p>Seed</p>');
         expect(config.root.initialData).toBe('<p>Root</p>');
+    });
+});
+
+describe('applyPoweredByPosition (issue #62)', () => {
+    it('defaults ui.poweredBy.position to "inside" when unset', () => {
+        const result = applyPoweredByPosition({});
+        expect((result.ui as Record<string, Record<string, unknown>>).poweredBy.position).toBe('inside');
+    });
+
+    it('preserves an existing ui.poweredBy.position (respects user override)', () => {
+        const result = applyPoweredByPosition({ ui: { poweredBy: { position: 'border' } } });
+        expect((result.ui as Record<string, Record<string, unknown>>).poweredBy.position).toBe('border');
+    });
+
+    it('keeps other ui.poweredBy keys intact while adding position', () => {
+        const result = applyPoweredByPosition({ ui: { poweredBy: { label: 'My Project' } } });
+        const poweredBy = (result.ui as Record<string, Record<string, unknown>>).poweredBy;
+        expect(poweredBy.label).toBe('My Project');
+        expect(poweredBy.position).toBe('inside');
+    });
+
+    it('preserves unrelated ui keys', () => {
+        const result = applyPoweredByPosition({ ui: { viewportOffset: { top: 50 } } });
+        const ui = result.ui as Record<string, unknown>;
+        expect(ui.viewportOffset).toEqual({ top: 50 });
+        expect((ui.poweredBy as Record<string, unknown>).position).toBe('inside');
+    });
+
+    it('is applied by buildCreateConfig', () => {
+        const el = document.createElement('div');
+        const created = buildCreateConfig(el, {}, {}, 'classic');
+        expect((created.ui as Record<string, Record<string, unknown>>).poweredBy.position).toBe('inside');
     });
 });

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/editor-config-normalizer.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/editor-config-normalizer.ts
@@ -260,7 +260,7 @@ export function buildCreateConfig(
     rootConfig: RootConfig,
     editorType: EditorType
 ): Record<string, unknown> {
-    const config: Record<string, unknown> = { ...baseConfig };
+    const config: Record<string, unknown> = applyPoweredByPosition({ ...baseConfig });
     const root: Record<string, unknown> = { ...rootConfig };
 
     delete config.attachTo;
@@ -279,6 +279,27 @@ export function buildCreateConfig(
         ...config,
         root: { ...root, element: editorElement },
     };
+}
+
+/**
+ * 默认把 'Powered By CKEditor' 徽标定位改为 'inside'（issue #62）。
+ *
+ * 徽标默认 position='border'，作为挂在 body 上的 balloon 用 JS 定位；在滚动容器内
+ * CKEditor 的重定位会滞后，导致徽标停在屏幕固定位置不随内容滚动消失。'inside' 让徽标
+ * 显示在编辑区边界内，随内容自然滚动，规避该问题。仅在消费端未显式配置 poweredBy.position
+ * 时设置默认值，尊重用户覆盖。
+ */
+export function applyPoweredByPosition(config: Record<string, unknown>): Record<string, unknown> {
+    const ui = isRecord(config.ui) ? { ...config.ui } : {};
+    const poweredBy = isRecord(ui.poweredBy) ? { ...ui.poweredBy } : {};
+
+    if (!hasOwn(poweredBy, 'position')) {
+        poweredBy.position = 'inside';
+    }
+
+    ui.poweredBy = poweredBy;
+    config.ui = ui;
+    return config;
 }
 
 function normalizeAIQuickActions(ai: Record<string, unknown>, warnings: string[]): void {


### PR DESCRIPTION
## Summary

Fixes #62 — the "Powered By CKEditor" badge stayed at a fixed viewport position when scrolling and wouldn't go away.

## Root cause

The badge defaults to `poweredBy.position: 'border'` — a balloon attached to `document.body`, positioned via JS. Inside a scroll container, CKEditor's reposition lags, so the badge sticks at fixed viewport coordinates.

## Fix

Default `ui.poweredBy.position` to `'inside'` in `buildCreateConfig` (via a new pure `applyPoweredByPosition` helper). The badge then renders **within the editing area** and scrolls naturally with content. Only sets the default when the consumer hasn't configured it — user overrides are respected.

Config-based — no fragile scroll-time DOM manipulation.

## Tests (regression guard)

5 new cases in `editor-config-normalizer.test.ts`:
- defaults to `'inside'` when unset
- respects an existing `position` (user override)
- preserves other `poweredBy` keys / unrelated `ui` keys
- applied through `buildCreateConfig`

Plus 2 existing `buildCreateConfig` assertions updated for the added `ui` field.

## Verification

```
tsc --noEmit → clean
vitest       → 119/119
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)