### PR TITLE
fix: disconnect annotation sidebar MutationObserver (leak)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/observer-lifecycle.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/observer-lifecycle.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { replaceObserver, disposeObserver, type Disconnectable } from './observer-lifecycle';
+
+function makeObserver(): Disconnectable & { disconnect: ReturnType<typeof vi.fn<() => void>> } {
+    return { disconnect: vi.fn<() => void>() };
+}
+
+describe('replaceObserver (review: MutationObserver leak / stacking)', () => {
+    it('creates and starts a new observer when none exists', () => {
+        const obs = makeObserver();
+        const start = vi.fn<(o: Disconnectable) => void>();
+        const result = replaceObserver(undefined, () => obs, start);
+        expect(result).toBe(obs);
+        expect(start).toHaveBeenCalledWith(obs);
+    });
+
+    it('disconnects the existing observer before creating a new one (no stacking)', () => {
+        const old = makeObserver();
+        const fresh = makeObserver();
+        const result = replaceObserver(old, () => fresh, () => {});
+        expect(old.disconnect).toHaveBeenCalledTimes(1);
+        expect(result).toBe(fresh);
+    });
+
+    it('does not call create/start before disconnecting the old one', () => {
+        const old = makeObserver();
+        const order: string[] = [];
+        old.disconnect.mockImplementation(() => order.push('disconnect-old'));
+        replaceObserver(
+            old,
+            () => { order.push('create-new'); return makeObserver(); },
+            () => { order.push('start-new'); },
+        );
+        expect(order).toEqual(['disconnect-old', 'create-new', 'start-new']);
+    });
+
+    it('repeated setup never leaves more than one live observer', () => {
+        let live = 0;
+        const make = () => {
+            live++;
+            return { disconnect: vi.fn(() => { live--; }) } as Disconnectable;
+        };
+        let held: Disconnectable | undefined;
+        for (let i = 0; i < 5; i++) {
+            held = replaceObserver(held, make, () => {});
+            expect(live).toBe(1); // exactly one observer alive after each setup
+        }
+        disposeObserver(held);
+        expect(live).toBe(0);
+    });
+});
+
+describe('disposeObserver', () => {
+    it('disconnects and returns undefined', () => {
+        const obs = makeObserver();
+        const result = disposeObserver(obs);
+        expect(obs.disconnect).toHaveBeenCalledTimes(1);
+        expect(result).toBeUndefined();
+    });
+
+    it('is a no-op when given undefined', () => {
+        expect(disposeObserver(undefined)).toBeUndefined();
+    });
+
+    it('is safe to call twice (idempotent teardown)', () => {
+        let held: Disconnectable | undefined = makeObserver();
+        held = disposeObserver(held);
+        expect(disposeObserver(held)).toBeUndefined();
+    });
+});

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/observer-lifecycle.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/observer-lifecycle.ts
@@ -1,0 +1,44 @@
+/**
+ * MutationObserver 生命周期管理（纯逻辑，便于单测）。
+ *
+ * 背景（review 发现）：组件里多处用 MutationObserver，若创建时不存引用、断开时不清理，
+ * 会在组件 disconnect 后泄漏（observer 持续持有回调与目标节点）。重复 setup 还会叠加多个
+ * observer。本工具把"创建即替换旧的 + 统一 dispose"的生命周期收敛成可测的纯逻辑，
+ * 与具体 editor/DOM 解耦。
+ *
+ * 用法：
+ *   this.annotationObs = replaceObserver(this.annotationObs, () => new MutationObserver(cb), o => o.observe(target, opts));
+ *   // disconnectedCallback:
+ *   this.annotationObs = disposeObserver(this.annotationObs);
+ */
+
+/** 最小 observer 契约：只要能 disconnect 即可（MutationObserver / ResizeObserver 等均满足）。 */
+export interface Disconnectable {
+    disconnect(): void;
+}
+
+/**
+ * 用新 observer 替换旧的：先断开既有（避免叠加/泄漏），再创建并启动新 observer。
+ * @param existing 当前持有的 observer（可能为 undefined）
+ * @param create   创建新 observer 的工厂
+ * @param start    启动观察（如 o.observe(target, opts)）
+ * @returns 新 observer，调用方应把它存回字段
+ */
+export function replaceObserver<T extends Disconnectable>(
+    existing: T | undefined,
+    create: () => T,
+    start: (observer: T) => void,
+): T {
+    existing?.disconnect();
+    const next = create();
+    start(next);
+    return next;
+}
+
+/**
+ * 断开并清理 observer。返回 undefined，便于调用方写 `this.obs = disposeObserver(this.obs)`。
+ */
+export function disposeObserver<T extends Disconnectable>(existing: T | undefined): undefined {
+    existing?.disconnect();
+    return undefined;
+}

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -25,6 +25,7 @@ import {
 } from './editor-config-normalizer';
 import { shouldRefreshSourceView } from './source-editing-refresh';
 import { decideDataChange } from './data-change-decision';
+import { replaceObserver, disposeObserver } from './observer-lifecycle';
 
 // 内置插件
 import CommentPermissionEnforcer from './comment-permission-enforcer';
@@ -314,6 +315,7 @@ export class VaadinCKEditor extends LitElement {
 
     // AI sidebar collapse observer for cleanup
     private aiSidebarCollapseObserver?: MutationObserver;
+    private annotationSidebarObserver?: MutationObserver;
 
     // Server communication
     private $server?: VaadinServer;
@@ -1145,12 +1147,14 @@ export class VaadinCKEditor extends LitElement {
         editable.addEventListener('scroll', syncPositions);
         syncPositions();
 
-        // MutationObserver 监听侧栏变化（新增/删除评论），自动重新对齐
-        new MutationObserver(syncPositions).observe(sidebar, {
-            childList: true,
-            subtree: true,
-            attributes: true
-        });
+        // MutationObserver 监听侧栏变化（新增/删除评论），自动重新对齐。
+        // 用 replaceObserver 存为字段并在 disconnectedCallback 中断开，避免组件断开后泄漏、
+        // 重复 setup 时叠加（review 发现）。
+        this.annotationSidebarObserver = replaceObserver(
+            this.annotationSidebarObserver,
+            () => new MutationObserver(syncPositions),
+            (o) => o.observe(sidebar, { childList: true, subtree: true, attributes: true }),
+        );
     }
 
     /**
@@ -2215,6 +2219,9 @@ export class VaadinCKEditor extends LitElement {
             this.aiSidebarCollapseObserver.disconnect();
             this.aiSidebarCollapseObserver = undefined;
         }
+
+        // Clean up annotation sidebar observer (review: was never disconnected → leak)
+        this.annotationSidebarObserver = disposeObserver(this.annotationSidebarObserver);
 
         // Clean up toolbar repaint timer
         if (this.toolbarRepaintTimeoutId) {


### PR DESCRIPTION
## Summary

Review finding (Warning, correctness): the annotation-sidebar `MutationObserver` in `setupAnnotationSidebarSync()` was created inline with no field reference, so it was **never disconnected** on `disconnectedCallback` — a memory leak. Repeated setup also stacked observers.

## Fix

New pure helper `observer-lifecycle.ts`:
- `replaceObserver(existing, create, start)` — disconnects any prior observer **before** creating/starting a new one (no stacking)
- `disposeObserver(existing)` — disconnects and returns `undefined` for teardown

The component stores the annotation observer in a field, sets it via `replaceObserver`, and disposes it in `disconnectedCallback`.

## Tests (regression guard)

`observer-lifecycle.test.ts` — **7 tests**: create-when-none, disconnect-before-create ordering, the **"never >1 live observer"** stacking guard, idempotent teardown.

## Verification

```
tsc --noEmit → clean
vitest       → 140/140
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)