### PR TITLE
fix: disconnect prior observer on repeated _startObserving (leak)

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/comment-permission-enforcer.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/comment-permission-enforcer.test.ts
@@ -159,6 +159,26 @@ describe('CommentPermissionEnforcer', () => {
             expect(disconnectSpy).toHaveBeenCalledTimes(1);
         });
 
+        it('重复 ready 事件不应叠加 observer（先断开旧的）', () => {
+            // review 回归：_startObserving 因重复 'ready' 被多次调用时，
+            // 必须先断开上一个 observer，否则泄漏多个 observer。
+            const { domRoot } = setupCommentDom();
+            const { editor, triggerReady } = createMockEditor(domRoot, 'user-1');
+            const plugin = new CommentPermissionEnforcer(editor as any);
+
+            plugin.init();
+            triggerReady(); // 第一次：注册 observer #1
+            triggerReady(); // 第二次：应先断开 #1，再注册 #2
+
+            // 两次 observe，但第二次注册前断开了第一个 → 不会叠加
+            expect(observeSpy).toHaveBeenCalledTimes(2);
+            expect(disconnectSpy).toHaveBeenCalledTimes(1);
+
+            // destroy 再断开当前 observer
+            plugin.destroy();
+            expect(disconnectSpy).toHaveBeenCalledTimes(2);
+        });
+
         it('Users 插件不可用时不应注册 observer', () => {
             const { domRoot } = setupCommentDom();
             const editor = {

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/comment-permission-enforcer.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/comment-permission-enforcer.ts
@@ -66,7 +66,10 @@ export default class CommentPermissionEnforcer extends Plugin {
         this._enforcePermissions(sidebar as HTMLElement, currentUserId);
 
         // 监听侧栏 DOM 变化（评论渲染、菜单展开等）
-        // 使用 _enforcing 标志避免 MutationObserver 与 style 修改之间的无限循环
+        // 使用 _enforcing 标志避免 MutationObserver 与 style 修改之间的无限循环。
+        // 先断开既有 observer：_startObserving 可能因重复 'ready' 事件被多次调用，
+        // 不清理会叠加多个 observer 泄漏（review 发现）。
+        this._observer?.disconnect();
         this._observer = new MutationObserver(() => {
             if (this._enforcing) return;
             this._enforcePermissions(sidebar as HTMLElement, currentUserId!);


### PR DESCRIPTION
## Summary

Review finding (Warning, correctness): `CommentPermissionEnforcer._startObserving()` runs on each editor `ready` event and reassigns `this._observer = new MutationObserver(...)` **without disconnecting the previous one**. A repeated/spurious `ready` leaked the prior observer, accumulating observers + mutation callbacks.

## Fix

Disconnect the existing observer before creating the new one (`this._observer?.disconnect()`). Self-contained — one line.

## Test (regression guard)

New case in `comment-permission-enforcer.test.ts`: two `triggerReady()` calls assert the first observer is disconnected before the second registers (`observeSpy` ×2, `disconnectSpy` ×1), and `destroy()` disconnects the current one (`disconnectSpy` ×2). 13 tests total.

## Verification

```
tsc --noEmit → clean
vitest       → 134/134
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)