### PR TITLE
refactor: make dark-theme ref counting pure & tested

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/dark-theme-refcount.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/dark-theme-refcount.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { createRefcount } from './dark-theme-refcount';
+
+describe('dark-theme-refcount (review: multi-instance ref counting)', () => {
+    it('starts at 0 with no apply/remove signal', () => {
+        const rc = createRefcount();
+        expect(rc.count).toBe(0);
+        expect(rc.justApplied).toBe(false);
+        expect(rc.justRemoved).toBe(false);
+    });
+
+    it('first acquire (0→1) signals justApplied', () => {
+        const rc = createRefcount().acquire();
+        expect(rc.count).toBe(1);
+        expect(rc.justApplied).toBe(true);
+        expect(rc.justRemoved).toBe(false);
+    });
+
+    it('subsequent acquires do NOT re-apply (only the 0→1 transition does)', () => {
+        const rc = createRefcount().acquire().acquire().acquire();
+        expect(rc.count).toBe(3);
+        expect(rc.justApplied).toBe(false);
+    });
+
+    it('last release (1→0) signals justRemoved', () => {
+        const rc = createRefcount().acquire().release();
+        expect(rc.count).toBe(0);
+        expect(rc.justRemoved).toBe(true);
+    });
+
+    it('non-final release does NOT remove (global style stays for remaining instances)', () => {
+        let rc = createRefcount().acquire().acquire(); // count=2
+        rc = rc.release(); // 2→1
+        expect(rc.count).toBe(1);
+        expect(rc.justRemoved).toBe(false);
+        rc = rc.release(); // 1→0
+        expect(rc.justRemoved).toBe(true);
+    });
+
+    it('balanced acquire/release across 3 instances applies once, removes once', () => {
+        let rc = createRefcount();
+        let applies = 0, removes = 0;
+        // 3 instances acquire
+        for (let i = 0; i < 3; i++) { rc = rc.acquire(); if (rc.justApplied) applies++; }
+        // 3 instances release
+        for (let i = 0; i < 3; i++) { rc = rc.release(); if (rc.justRemoved) removes++; }
+        expect(applies).toBe(1);
+        expect(removes).toBe(1);
+        expect(rc.count).toBe(0);
+    });
+
+    it('release never goes below 0 and an over-release does not falsely signal removal', () => {
+        const rc = createRefcount().release();
+        expect(rc.count).toBe(0);
+        expect(rc.justRemoved).toBe(false); // releasing at 0 must not trigger style removal
+    });
+
+    it('is immutable — acquire/release return new values without mutating the original', () => {
+        const base = createRefcount().acquire(); // count=1
+        const a = base.acquire();
+        const b = base.release();
+        expect(base.count).toBe(1);
+        expect(a.count).toBe(2);
+        expect(b.count).toBe(0);
+    });
+});

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/dark-theme-refcount.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/dark-theme-refcount.ts
@@ -1,0 +1,45 @@
+/**
+ * 全局 dark 主题引用计数（纯逻辑，便于单测）。
+ *
+ * 背景（review 发现）：dark 主题的 CSS 变量与 <style> 是全局共享的，多个编辑器实例
+ * 需要"第一个进来时应用、最后一个离开时移除"。原实现用模块级可变变量 + 散落的
+ * 增减判断，难以单测且对异常/HMR 脆弱。这里把计数状态与"是否应用/是否移除"的判断
+ * 收敛为一个不可变的纯计数器，逻辑可测、不依赖 DOM。
+ *
+ * 用法：
+ *   refcount = refcount.acquire(); if (refcount.justApplied) applyGlobalStyle();
+ *   refcount = refcount.release(); if (refcount.justRemoved) removeGlobalStyle();
+ */
+
+export interface RefcountResult {
+    /** 当前计数 */
+    readonly count: number;
+    /** 本次 acquire 是否使计数从 0 升到 1（应应用全局样式） */
+    readonly justApplied: boolean;
+    /** 本次 release 是否使计数降到 0（应移除全局样式） */
+    readonly justRemoved: boolean;
+    acquire(): RefcountResult;
+    release(): RefcountResult;
+}
+
+function make(count: number, justApplied: boolean, justRemoved: boolean): RefcountResult {
+    return {
+        count,
+        justApplied,
+        justRemoved,
+        acquire() {
+            const next = count + 1;
+            return make(next, next === 1, false);
+        },
+        release() {
+            // 不允许降到负数；只有真正归零的那次 release 才触发移除
+            const next = Math.max(0, count - 1);
+            return make(next, false, count > 0 && next === 0);
+        },
+    };
+}
+
+/** 创建初始引用计数（count=0）。 */
+export function createRefcount(initial = 0): RefcountResult {
+    return make(Math.max(0, initial), false, false);
+}

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/theme-manager.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/theme-manager.ts
@@ -7,6 +7,7 @@
  * - OS dark mode detection
  * - Theme reference counting for multi-instance support
  */
+import { createRefcount } from './dark-theme-refcount';
 
 /**
  * Dark theme CSS variables for CKEditor
@@ -78,7 +79,7 @@ export const DARK_THEME_VARS: Record<string, string> = {
  * Tracks how many editor instances are using dark theme to ensure
  * CSS variables are only removed when the last dark theme instance is destroyed.
  */
-let darkThemeRefCount = 0;
+let darkThemeRefcount = createRefcount();
 
 /**
  * Dark theme style element ID
@@ -214,9 +215,9 @@ export class ThemeManager {
             return;
         }
         this.isDarkThemeActive = true;
-        darkThemeRefCount++;
+        darkThemeRefcount = darkThemeRefcount.acquire();
 
-        if (darkThemeRefCount === 1) {
+        if (darkThemeRefcount.justApplied) {
             const rootStyle = document.documentElement.style;
             Object.entries(DARK_THEME_VARS).forEach(([key, value]) => {
                 rootStyle.setProperty(key, value);
@@ -240,9 +241,9 @@ export class ThemeManager {
             return;
         }
         this.isDarkThemeActive = false;
-        darkThemeRefCount = Math.max(0, darkThemeRefCount - 1);
+        darkThemeRefcount = darkThemeRefcount.release();
 
-        if (darkThemeRefCount === 0) {
+        if (darkThemeRefcount.justRemoved) {
             const rootStyle = document.documentElement.style;
             Object.keys(DARK_THEME_VARS).forEach((key) => {
                 rootStyle.removeProperty(key);


### PR DESCRIPTION
## Summary

Review finding (Warning, correctness): the global dark-theme ref count was a bare module-level `let darkThemeRefCount` with the apply/remove threshold logic (`==1`/`==0`) inlined and scattered across `initDarkTheme`/`removeDarkTheme`. Correct in the normal flow, but untestable and fragile to over-release / test-isolation / HMR.

## Fix

Extract an **immutable pure** refcount (`dark-theme-refcount.ts`): `acquire()`/`release()` return the new count plus `justApplied` (0→1) / `justRemoved` (1→0) signals. `ThemeManager` drives the global CSS variables + `<style>` off those signals.

Behavior unchanged for the multi-instance case ("apply on first, remove on last"). Hardened: release can no longer underflow below 0 or falsely signal removal.

## Tests

`dark-theme-refcount.test.ts` — **8 tests**: first-apply, no re-apply on nested acquires, last-remove, non-final release keeps style, balanced 3-instance apply-once/remove-once, over-release safety, immutability.

Existing `theme-manager.test.ts` (17) stays green → behavior preserved.

## Verification

```
tsc --noEmit → clean
vitest       → 141/141
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)