### PR TITLE
fix: plugin-resolver — registry cleanup, loadErrors parity, doc clarity

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
@@ -11,6 +11,7 @@ import {
     PluginResolver,
     PLUGIN_REGISTRY,
     registerCKEditorPlugin,
+    unregisterCKEditorPlugin,
     getGlobalPluginRegistry,
     type FilterOptions,
 } from './plugin-resolver';
@@ -228,6 +229,30 @@ describe('Global Plugin Registry', () => {
         expect((window as any)[key]).toBeDefined();
         expect((window as any)[key]['SymbolTest']).toEqual({ test: true });
     });
+
+    // review: registry had no cleanup path → unregister API
+    it('unregisterCKEditorPlugin removes a registered plugin and returns true', () => {
+        registerCKEditorPlugin('Removable', class R {});
+        expect(getGlobalPluginRegistry()['Removable']).toBeDefined();
+
+        expect(unregisterCKEditorPlugin('Removable')).toBe(true);
+        expect(getGlobalPluginRegistry()['Removable']).toBeUndefined();
+    });
+
+    it('unregisterCKEditorPlugin returns false when the plugin was not registered', () => {
+        expect(unregisterCKEditorPlugin('NeverRegistered')).toBe(false);
+    });
+
+    it('unregister only removes the named plugin, leaving others intact', () => {
+        registerCKEditorPlugin('KeepMe', class K {});
+        registerCKEditorPlugin('DropMe', class D {});
+
+        unregisterCKEditorPlugin('DropMe');
+
+        const registry = getGlobalPluginRegistry();
+        expect(registry['DropMe']).toBeUndefined();
+        expect(registry['KeepMe']).toBeDefined();
+    });
 });
 
 describe('PluginResolver', () => {
@@ -264,6 +289,24 @@ describe('PluginResolver', () => {
             expect(logger.warn).toHaveBeenCalledWith(
                 'Plugin not found in registry: UnknownPlugin'
             );
+        });
+
+        it('records a missing standard plugin in loadErrors (review: parity with premium/custom)', async () => {
+            const configs = [
+                { name: 'Bold', premium: false },
+                { name: 'NotARealPlugin', premium: false },
+            ];
+
+            await resolver.resolvePlugins(configs);
+
+            expect(resolver.loadErrors).toContain(
+                'Plugin not found in registry: NotARealPlugin'
+            );
+        });
+
+        it('leaves loadErrors empty when all standard plugins resolve', async () => {
+            await resolver.resolvePlugins([{ name: 'Bold', premium: false }]);
+            expect(resolver.loadErrors).toHaveLength(0);
         });
 
         it('should respect filter options', async () => {

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
@@ -370,6 +370,26 @@ export function registerCKEditorPlugin(name: string, plugin: unknown): void {
 }
 
 /**
+ * Remove a custom plugin from the global registry.
+ *
+ * The registry is a process-global (window-level) map: custom plugins registered
+ * via {@link registerCKEditorPlugin} live for the page lifetime. Long-lived apps that
+ * register plugins dynamically can call this to release entries they no longer need
+ * (review: the registry previously had no cleanup path → entries accumulated).
+ *
+ * @param name - The plugin name previously passed to registerCKEditorPlugin
+ * @returns true if an entry was removed, false if no entry existed
+ */
+export function unregisterCKEditorPlugin(name: string): boolean {
+    const registry = getGlobalPluginRegistry();
+    if (Object.prototype.hasOwnProperty.call(registry, name)) {
+        delete registry[name];
+        return true;
+    }
+    return false;
+}
+
+/**
  * Filter result from plugin conflict detection.
  */
 export interface FilterResult {
@@ -384,9 +404,13 @@ export interface FilterResult {
  */
 export interface FilterOptions {
     /**
-     * When true, disables automatic plugin filtering.
-     * Plugins requiring special configuration and unavailable plugins will still be loaded,
-     * which may cause runtime errors if not properly configured.
+     * ⚠️ Note the inverted sense of this flag (kept for backward compatibility):
+     * `strictPluginLoading = true` actually means "load everything verbatim, do NOT
+     * filter". When true, conflicting plugins, plugins requiring special configuration,
+     * and unavailable plugins are all left in the list, which may cause runtime errors
+     * if not properly configured. The default (`false`) applies the safety filtering.
+     *
+     * In short: `false` = filtered/safe (default), `true` = unfiltered/raw.
      *
      * @default false
      */
@@ -559,7 +583,11 @@ export class PluginResolver {
             if (plugin) {
                 resolvedPlugins.push(plugin);
             } else {
-                this.logger.warn(`Plugin not found in registry: ${pluginConfig.name}`);
+                // review: 缺失的 standard plugin 此前只 warn，不进 loadErrors，
+                // 与 premium/custom 失败的报告方式不一致。统一记入 loadErrors。
+                const errorMsg = `Plugin not found in registry: ${pluginConfig.name}`;
+                this.logger.warn(errorMsg);
+                this.loadErrors.push(errorMsg);
             }
         }
 


### PR DESCRIPTION
## Summary

Three review findings in `plugin-resolver.ts` (bundled in one PR since they share the file → avoids merge conflicts with other review branches).

## Fixes

1. **(correctness) Registry cleanup** — the global custom-plugin registry had no removal path, so entries accumulated for the page lifetime. Add `unregisterCKEditorPlugin(name): boolean` as the additive counterpart to `registerCKEditorPlugin`.

2. **(data-structure) loadErrors parity** — a missing standard plugin only logged a warning and was NOT recorded in `loadErrors`, unlike premium/custom failures. Now pushed to `loadErrors` for consistent error reporting.

3. **(docs) `strictPluginLoading` inverted semantics** — `true` actually means "don't filter". Renaming would break the published API, so the JSDoc is rewritten to make the inverted sense unmistakable (`false` = filtered/safe default, `true` = unfiltered/raw). **No behavior change.**

## Tests

+5 in `plugin-resolver.test.ts`: unregister removes/returns true, missing returns false, only-named removed; missing standard plugin recorded in `loadErrors`; `loadErrors` empty on full success. **31 tests total.**

## Verification

```
tsc --noEmit → clean
vitest       → 138/138
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)