### PR TITLE
fix: reject oversized uploads before base64 decode + guard duplicate notify

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/internal/UploadManager.java
+++ b/src/main/java/com/wontlost/ckeditor/internal/UploadManager.java
@@ -5,6 +5,7 @@ import com.wontlost.ckeditor.handler.UploadHandler;
 import java.io.ByteArrayInputStream;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -112,6 +113,8 @@ public class UploadManager {
     private final UploadHandler.UploadConfig uploadConfig;
     private final UploadResultCallback resultCallback;
     private final Map<String, UploadTask> activeTasks = new ConcurrentHashMap<>();
+    // 已通知的 uploadId 集合：即使 early-failure 路径 task==null，也能防止同一上传重复回调（review 发现）。
+    private final Set<String> notifiedUploadIds = ConcurrentHashMap.newKeySet();
     private final long uploadTimeoutSeconds;
 
     /**
@@ -161,6 +164,22 @@ public class UploadManager {
             logger.log(Level.WARNING, "Upload {0} rejected: no upload handler configured", uploadId);
             notifyError(uploadId, null, "No upload handler configured");
             return;
+        }
+
+        // 在 decode 前按 base64 长度估算解码后大小，超过上限直接拒绝，
+        // 避免恶意超大 base64 先解码成巨大字节数组导致 OOM/DoS（review 发现）。
+        // base64 每 4 字符编码 3 字节，估算 = length/4*3，留足余量。
+        if (base64Data != null) {
+            long estimatedSize = (long) base64Data.length() / 4 * 3;
+            long maxFileSize = uploadConfig.getMaxFileSize();
+            if (estimatedSize > maxFileSize) {
+                logger.log(Level.INFO,
+                    "Upload {0} rejected before decode: estimated {1} bytes exceeds max {2} bytes",
+                    new Object[]{uploadId, estimatedSize, maxFileSize});
+                notifyError(uploadId, null,
+                    "File exceeds maximum allowed size of " + maxFileSize + " bytes");
+                return;
+            }
         }
 
         byte[] fileData;
@@ -391,6 +410,7 @@ public class UploadManager {
             cancelUpload(uploadId);
         }
         activeTasks.clear();
+        notifiedUploadIds.clear();
     }
 
     /**
@@ -405,13 +425,15 @@ public class UploadManager {
      * Notify upload result with double notification guard
      */
     private void notifyResult(String uploadId, UploadTask task, String url, String error) {
-        // Double notification guard
+        // Double notification guard：以 uploadId 集合作为唯一守卫，
+        // 即使 early-failure 路径 task==null 也能防止重复回调（review 发现）。
+        // add() 原子地"首次插入返回 true"，确保每个 uploadId 只通知一次。
+        if (!notifiedUploadIds.add(uploadId)) {
+            logger.log(Level.FINE, "Skipping duplicate notification for upload {0}", uploadId);
+            return;
+        }
         if (task != null) {
             synchronized (task) {
-                if (task.isNotified()) {
-                    logger.log(Level.FINE, "Skipping duplicate notification for upload {0}", uploadId);
-                    return;
-                }
                 task.setNotified(true);
             }
         }

--- a/src/test/java/com/wontlost/ckeditor/UploadManagerTest.java
+++ b/src/test/java/com/wontlost/ckeditor/UploadManagerTest.java
@@ -313,4 +313,62 @@ class UploadManagerTest {
         assertDoesNotThrow(() ->
             manager.handleUpload("timeout-4", "test.jpg", "image/jpeg", createBase64Data("test")));
     }
+
+    // review: base64 应在 decode 前按长度估算大小拦截，避免超大上传 OOM
+    @Test
+    @DisplayName("handleUpload should reject oversized base64 BEFORE decoding (OOM guard)")
+    void handleUploadRejectsOversizedBeforeDecode() throws Exception {
+        UploadHandler.UploadConfig config = new UploadHandler.UploadConfig().setMaxFileSize(16);
+        // 这个 handler 一旦被调用就说明数据已被 decode —— 不应发生
+        AtomicReference<Boolean> handlerInvoked = new AtomicReference<>(false);
+        UploadHandler handler = (ctx, stream) -> {
+            handlerInvoked.set(true);
+            return CompletableFuture.completedFuture(new UploadHandler.UploadResult("url"));
+        };
+        manager = new UploadManager(handler, config, createCallback());
+
+        // 远超 16 字节上限的内容
+        String big = createBase64Data("x".repeat(10_000));
+        manager.handleUpload("oom-1", "big.bin", "image/jpeg", big);
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals("oom-1", lastUploadId.get());
+        assertNull(lastUrl.get());
+        assertNotNull(lastError.get());
+        assertTrue(lastError.get().toLowerCase().contains("size") || lastError.get().contains("exceeds"),
+            "error should mention size limit, got: " + lastError.get());
+        assertFalse(handlerInvoked.get(), "handler must not run — data should be rejected before decode");
+    }
+
+    @Test
+    @DisplayName("handleUpload should allow data within size limit")
+    void handleUploadAllowsWithinSizeLimit() throws Exception {
+        UploadHandler.UploadConfig config = new UploadHandler.UploadConfig().setMaxFileSize(1024);
+        manager = new UploadManager(createSuccessHandler("https://example.com/ok.jpg"), config, createCallback());
+
+        manager.handleUpload("ok-size", "ok.jpg", "image/jpeg", createBase64Data("small"));
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals("https://example.com/ok.jpg", lastUrl.get());
+        assertNull(lastError.get());
+    }
+
+    // review: double-notification 守卫此前在 task==null（early failure）时被绕过
+    @Test
+    @DisplayName("notifyResult must guard duplicates even on early-failure paths (no task)")
+    void earlyFailureNotifiesExactlyOnce() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger callbackCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        UploadManager.UploadResultCallback countingCallback = (id, url, err) -> callbackCount.incrementAndGet();
+
+        // 无 handler → 走 early-failure 路径（task==null）
+        manager = new UploadManager(null, null, countingCallback);
+
+        // 同一 uploadId 触发两次 early failure
+        manager.handleUpload("dup-1", "a.jpg", "image/jpeg", createBase64Data("x"));
+        manager.handleUpload("dup-1", "a.jpg", "image/jpeg", createBase64Data("x"));
+
+        // 即使 task==null，uploadId 守卫也保证只回调一次
+        assertEquals(1, callbackCount.get(),
+            "same uploadId must notify exactly once even without an UploadTask");
+    }
 }


### PR DESCRIPTION
## Summary

Two review findings in `UploadManager` (bundled — same file).

## Fixes

1. **(security / DoS — was the highest-priority finding) base64 OOM**: the upload was `Base64.getDecoder().decode(...)`-ed **before** any size validation, so a malicious oversized base64 string allocated a huge `byte[]` and could OOM the server. Now the decoded size is estimated from the base64 length (`len/4*3`) and rejected above `uploadConfig.getMaxFileSize()` **before** decoding.

2. **(correctness) duplicate-notification race**: the guard lived on the `UploadTask`, but early-failure paths pass `task == null`, bypassing it — the same `uploadId` could fire `onComplete` twice. Added a `notifiedUploadIds` set (`ConcurrentHashMap.newKeySet()`) as the primary guard; `add()` atomically admits only the first notification regardless of whether a task exists. Cleared on `cleanup()`.

## Tests (+3 in UploadManagerTest)

- oversized base64 rejected **before** decode (handler never runs; error mentions size)
- within-limit upload still succeeds
- same `uploadId` on the no-handler early-failure path notifies **exactly once**

## Verification

```
mvn -B clean test → 496/496 (was 493)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)