### PR TITLE
fix: fail-fast on plugin cycle + advisory for collab plugins without CloudServices

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/CKEditorPluginDependencies.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorPluginDependencies.java
@@ -497,9 +497,11 @@ public final class CKEditorPluginDependencies {
             List<CKEditorPlugin> sorted) {
 
         if (visiting.contains(plugin)) {
-            // Cycle detected - log a warning as this indicates a dependency graph issue
-            logger.log(Level.WARNING, "Circular dependency detected involving plugin: {0}", plugin.getJsName());
-            return;
+            // 检测到循环依赖：fail-fast 抛异常并指明涉及的插件，而非静默 log+return
+            // 返回残缺的排序结果（review 发现：静默失败会让用户拿到不完整的插件列表而不自知）。
+            throw new IllegalStateException(
+                "Circular plugin dependency detected involving '" + plugin.getJsName()
+                    + "'. The plugin dependency graph must be acyclic; check DEPENDENCIES for a cycle.");
         }
         if (visited.contains(plugin)) {
             return;
@@ -704,6 +706,40 @@ public final class CKEditorPluginDependencies {
         }
 
         return missing;
+    }
+
+    /**
+     * 协作类 premium 插件：可独立工作，但缺少 CloudServices 时实时同步会静默失效。
+     * 这些插件刻意不设为 CloudServices 的硬依赖（保留独立使用能力），
+     * 改为通过 {@link #getCollaborationPluginsMissingCloudServices} 给出软告警。
+     */
+    private static final Set<String> COLLABORATION_PLUGINS_SOFT_CLOUD =
+        Set.of("Comments", "TrackChanges");
+
+    /**
+     * 软校验：返回已启用但缺少 CloudServices 的协作类 premium 插件（Comments / TrackChanges）。
+     *
+     * <p>这些插件能独立工作，因此不作为硬依赖强制注入 CloudServices；但缺少 CloudServices 时
+     * 实时同步会静默失效（review 发现）。调用方（如 builder）可据此向用户发出告警，
+     * 而非让协作功能无声降级。</p>
+     *
+     * @param customPlugins 当前启用的自定义/premium 插件
+     * @param plugins 当前已解析的标准插件集合（用于判断是否已包含 CLOUD_SERVICES）
+     * @return 缺少 CloudServices 的协作插件名集合（可能为空）
+     */
+    public static Set<String> getCollaborationPluginsMissingCloudServices(
+            Collection<CustomPlugin> customPlugins,
+            Set<CKEditorPlugin> plugins) {
+        Set<String> result = new java.util.LinkedHashSet<>();
+        if (customPlugins == null || (plugins != null && plugins.contains(CKEditorPlugin.CLOUD_SERVICES))) {
+            return result;
+        }
+        for (CustomPlugin customPlugin : customPlugins) {
+            if (COLLABORATION_PLUGINS_SOFT_CLOUD.contains(customPlugin.getJsName())) {
+                result.add(customPlugin.getJsName());
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/com/wontlost/ckeditor/CKEditorPluginDependenciesTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorPluginDependenciesTest.java
@@ -448,6 +448,64 @@ class CKEditorPluginDependenciesTest {
             .contains(CKEditorPlugin.WIDGET, CKEditorPlugin.WIDGET_TOOLBAR_REPOSITORY);
     }
 
+    // ==================== review: cycle fail-fast + collaboration soft-dep ====================
+
+    @Test
+    @DisplayName("topologicalSort returns a complete order for the (acyclic) real plugin graph")
+    void topologicalSortIsCompleteForRealGraph() {
+        // 真实静态依赖图无环，排序应返回全部输入插件，顺序中依赖先于被依赖者
+        Set<CKEditorPlugin> input = EnumSet.of(
+            CKEditorPlugin.BLOCK_TOOLBAR, CKEditorPlugin.WIDGET,
+            CKEditorPlugin.WIDGET_TOOLBAR_REPOSITORY, CKEditorPlugin.ESSENTIALS);
+        List<CKEditorPlugin> sorted = CKEditorPluginDependencies.topologicalSort(input);
+
+        assertThat(sorted).containsExactlyInAnyOrderElementsOf(input);
+        // 依赖必须排在被依赖者之前
+        assertThat(sorted.indexOf(CKEditorPlugin.WIDGET))
+            .isLessThan(sorted.indexOf(CKEditorPlugin.BLOCK_TOOLBAR));
+    }
+
+    @Test
+    @DisplayName("getCollaborationPluginsMissingCloudServices flags Comments/TrackChanges without CloudServices")
+    void collaborationMissingCloudServicesFlagged() {
+        Set<CKEditorPlugin> base = EnumSet.of(CKEditorPlugin.ESSENTIALS);
+        List<CustomPlugin> premium = List.of(
+            CustomPlugin.fromPremium("Comments"),
+            CustomPlugin.fromPremium("TrackChanges"));
+
+        Set<String> missing =
+            CKEditorPluginDependencies.getCollaborationPluginsMissingCloudServices(premium, base);
+
+        assertThat(missing).containsExactlyInAnyOrder("Comments", "TrackChanges");
+    }
+
+    @Test
+    @DisplayName("collaboration advisory is silent once CloudServices is present")
+    void collaborationAdvisorySilentWithCloudServices() {
+        Set<CKEditorPlugin> withCloud = EnumSet.of(CKEditorPlugin.ESSENTIALS, CKEditorPlugin.CLOUD_SERVICES);
+        List<CustomPlugin> premium = List.of(CustomPlugin.fromPremium("Comments"));
+
+        assertThat(CKEditorPluginDependencies.getCollaborationPluginsMissingCloudServices(premium, withCloud))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("collaboration advisory ignores non-collaboration premium plugins")
+    void collaborationAdvisoryIgnoresOtherPremium() {
+        Set<CKEditorPlugin> base = EnumSet.of(CKEditorPlugin.ESSENTIALS);
+        List<CustomPlugin> premium = List.of(CustomPlugin.fromPremium("ExportPdf"));
+
+        assertThat(CKEditorPluginDependencies.getCollaborationPluginsMissingCloudServices(premium, base))
+            .isEmpty();
+    }
+
+    @Test
+    @DisplayName("collaboration advisory is null-safe")
+    void collaborationAdvisoryNullSafe() {
+        assertThat(CKEditorPluginDependencies.getCollaborationPluginsMissingCloudServices(null, null))
+            .isEmpty();
+    }
+
     // ==================== OSGi Manifest Validation ====================
 
     @Test


### PR DESCRIPTION
## Summary

Two review findings (Warning, correctness) in `CKEditorPluginDependencies` — same file, one PR.

## Fixes

1. **Cycle silently truncated the sort** — `topologicalSortVisit()` detected a circular dependency, logged a WARNING, and returned, producing a **silently incomplete** sorted plugin list (→ missing plugins, hard-to-debug runtime failures). Now throws `IllegalStateException` naming the offending plugin (**fail-fast**). The real static graph is acyclic, so this never triggers today — it just stops a future cycle from degrading silently.

2. **Collaboration plugins degrade silently without CloudServices** — `Comments`/`TrackChanges` work standalone but their real-time sync silently fails without CloudServices, and they're deliberately **not** hard-dependent on it (preserves standalone use). Add `getCollaborationPluginsMissingCloudServices(...)` — a **soft advisory** the builder/consumer can surface. No behavior change, no forced hard dependency.

## Tests (+5)

Topo-sort completeness + dependency ordering on the real graph; advisory flags `Comments`/`TrackChanges` without CloudServices, is silent with it, ignores other premium plugins, null-safe.

## Verification

```
mvn -B clean test → 498/498 (all green)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)