### PR TITLE
fix: null MIME type shows 'unknown' instead of literal 'null'

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/handler/UploadHandler.java
+++ b/src/main/java/com/wontlost/ckeditor/handler/UploadHandler.java
@@ -247,10 +247,15 @@ public interface UploadHandler {
                     context.getFileSize(), maxFileSize);
             }
 
-            // Empty allowed list means all types are permitted
-            if (!allowedMimeTypes.isEmpty() && !allowedMimeTypes.contains(context.getMimeType())) {
-                return String.format("MIME type '%s' is not allowed. Allowed types: %s",
-                    context.getMimeType(), String.join(", ", allowedMimeTypes));
+            // Empty allowed list means all types are permitted.
+            // null mimeType 显示为有意义的 "unknown" 而非字面 "null"（review 发现）。
+            if (!allowedMimeTypes.isEmpty()) {
+                String mimeType = context.getMimeType();
+                if (mimeType == null || !allowedMimeTypes.contains(mimeType)) {
+                    String shown = (mimeType != null) ? mimeType : "unknown";
+                    return String.format("MIME type '%s' is not allowed. Allowed types: %s",
+                        shown, String.join(", ", allowedMimeTypes));
+                }
             }
 
             return null;

--- a/src/test/java/com/wontlost/ckeditor/UploadConfigTest.java
+++ b/src/test/java/com/wontlost/ckeditor/UploadConfigTest.java
@@ -162,6 +162,29 @@ class UploadConfigTest {
         assertTrue(error.contains("null"));
     }
 
+    // review: null mimeType 应被拒绝，且错误信息显示 "unknown" 而非字面 "null"
+    @Test
+    @DisplayName("validate should reject null MIME type with a meaningful 'unknown' message")
+    void validateNullMimeType() {
+        config.setAllowedMimeTypes("image/jpeg", "image/png");
+        UploadHandler.UploadContext context = createMockContext(null, 1024);
+
+        String error = config.validate(context);
+
+        assertNotNull(error, "null mime type must be rejected when a whitelist is set");
+        assertTrue(error.contains("not allowed"), "should report disallowed: " + error);
+        assertTrue(error.contains("unknown"), "should show 'unknown' not 'null': " + error);
+        assertFalse(error.contains("'null'"), "must not print the literal 'null': " + error);
+    }
+
+    @Test
+    @DisplayName("validate should allow null MIME type when whitelist is empty")
+    void validateNullMimeTypeEmptyWhitelist() {
+        config.setAllowedMimeTypes(); // empty = allow all
+        UploadHandler.UploadContext context = createMockContext(null, 1024);
+        assertNull(config.validate(context));
+    }
+
     private UploadHandler.UploadContext createMockContext(String mimeType, long fileSize) {
         return new UploadHandler.UploadContext("test.file", mimeType, fileSize);
     }


### PR DESCRIPTION
## Summary

Review finding (Warning, correctness): `UploadConfig.validate()` passed `context.getMimeType()` (possibly null) directly into `allowedMimeTypes.contains()` and the error message, so a null mime type produced the confusing message `MIME type 'null' is not allowed`.

## Fix

Reject null mime type explicitly when a whitelist is set, and render it as `unknown` in the message.

## Tests (+2 in UploadConfigTest)

- null mime type with a whitelist → rejected, message shows `unknown` (never literal `null`)
- null mime type with an empty whitelist → still allowed (allow-all mode)

## Verification

```
mvn -B clean test → all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)