### PR TITLE
test: cover setValue rapid-succession + concurrent upload cancel/complete

### DIFF
--- a/src/test/java/com/wontlost/ckeditor/UploadManagerTest.java
+++ b/src/test/java/com/wontlost/ckeditor/UploadManagerTest.java
@@ -371,4 +371,50 @@ class UploadManagerTest {
         assertEquals(1, callbackCount.get(),
             "same uploadId must notify exactly once even without an UploadTask");
     }
+
+    // review (test-gap): 并发 cancel vs complete 必须只回调一次
+    @org.junit.jupiter.api.RepeatedTest(20)
+    @DisplayName("concurrent cancel and completion notify the callback exactly once")
+    void concurrentCancelAndCompleteNotifyOnce() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger callbackCount =
+            new java.util.concurrent.atomic.AtomicInteger(0);
+        CountDownLatch done = new CountDownLatch(1);
+        UploadManager.UploadResultCallback countingCallback = (id, url, err) -> {
+            callbackCount.incrementAndGet();
+            done.countDown();
+        };
+
+        // handler 返回一个可被外部 race 完成的 future
+        CompletableFuture<UploadHandler.UploadResult> future = new CompletableFuture<>();
+        CountDownLatch handlerStarted = new CountDownLatch(1);
+        UploadHandler racingHandler = (ctx, stream) -> {
+            handlerStarted.countDown();
+            return future;
+        };
+
+        manager = new UploadManager(racingHandler, null, countingCallback);
+        manager.handleUpload("race-1", "r.jpg", "image/jpeg", createBase64Data("data"));
+        assertTrue(handlerStarted.await(2, TimeUnit.SECONDS));
+
+        // 同时从两个线程触发 complete 与 cancel，制造竞态
+        CountDownLatch go = new CountDownLatch(1);
+        Thread completer = new Thread(() -> {
+            try { go.await(); } catch (InterruptedException ignored) { }
+            future.complete(new UploadHandler.UploadResult("https://example.com/r.jpg"));
+        });
+        Thread canceller = new Thread(() -> {
+            try { go.await(); } catch (InterruptedException ignored) { }
+            manager.cancelUpload("race-1");
+        });
+        completer.start();
+        canceller.start();
+        go.countDown(); // 同时放行
+        completer.join(2000);
+        canceller.join(2000);
+
+        assertTrue(done.await(2, TimeUnit.SECONDS), "callback should fire");
+        // 关键断言：无论 cancel 还是 complete 先到，回调只能发生一次
+        assertEquals(1, callbackCount.get(),
+            "concurrent cancel/complete must notify exactly once, never twice");
+    }
 }

--- a/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
+++ b/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
@@ -287,6 +287,56 @@ class VaadinCKEditorIntegrationTest {
             assertEquals("<p>second</p>", lastNew.get());
             assertEquals("<p>second</p>", editor.getValue());
         }
+
+        @Test
+        @DisplayName("rapid successive setValue calls keep the last value and listener stays consistent")
+        void testRapidSuccessiveSetValuePreservesLast() {
+            // 审查发现的测试盲区：快速连续 setValue 应保留最后一个值，
+            // 且监听器最终读到的值与 getValue() 一致。
+            AtomicReference<String> lastListenerValue = new AtomicReference<>();
+            editor.addValueChangeListener(event -> lastListenerValue.set(event.getValue()));
+
+            for (int i = 0; i < 50; i++) {
+                editor.setValue("<p>v" + i + "</p>");
+            }
+
+            assertEquals("<p>v49</p>", editor.getValue(), "last setValue wins");
+            assertEquals("<p>v49</p>", lastListenerValue.get(),
+                "listener's final value must equal getValue()");
+        }
+
+        @Test
+        @DisplayName("rapid identical setValue calls fire exactly one change event")
+        void testRapidIdenticalSetValueFiresOnce() {
+            // 连续设置相同值只应触发一次事件（首次 ""→值），其余被 equals 守卫拦截。
+            AtomicInteger fireCount = new AtomicInteger(0);
+            editor.addValueChangeListener(event -> fireCount.incrementAndGet());
+
+            for (int i = 0; i < 10; i++) {
+                editor.setValue("<p>same</p>");
+            }
+
+            assertEquals(1, fireCount.get(),
+                "only the first distinct value should fire; identical repeats are guarded");
+            assertEquals("<p>same</p>", editor.getValue());
+        }
+
+        @Test
+        @DisplayName("interleaved setValue (server) and setModelValue (client) keep last value consistent")
+        void testInterleavedServerClientChanges() {
+            // 混合服务端 setValue 与客户端 setModelValue，最终值与监听器读到的值必须一致。
+            AtomicReference<String> lastListenerValue = new AtomicReference<>();
+            editor.addValueChangeListener(event -> lastListenerValue.set(event.getValue()));
+
+            editor.setValue("<p>server-1</p>");
+            editor.setModelValue("<p>client-1</p>", true);
+            editor.setValue("<p>server-2</p>");
+            editor.setModelValue("<p>client-2</p>", true);
+
+            assertEquals("<p>client-2</p>", editor.getValue());
+            assertEquals("<p>client-2</p>", lastListenerValue.get(),
+                "listener's final value must match getValue() after interleaved changes");
+        }
     }
 
     // ==================== Content Stats Tests ====================


### PR DESCRIPTION
## Summary

Fills the two **test-gap** findings from the review (test-only; no production code change).

## Added tests

1. **`setValue()` edge cases** (`VaadinCKEditorIntegrationTest`):
   - 50 rapid `setValue` calls → last value wins, listener's final value equals `getValue()`
   - 10 identical `setValue` calls → exactly one change event (equals-guard)
   - interleaved server `setValue` / client `setModelValue` → final value consistent

2. **Concurrent cancel-vs-complete** (`UploadManagerTest`, `@RepeatedTest(20)`):
   - race `future.complete()` against `cancelUpload()` from two threads and assert the callback fires **exactly once** — exercises the #105 double-notification guard under real concurrency, repeated 20× to catch nondeterminism.

## Verification

```
mvn -B clean test → 526/526 (race test green across all 20 iterations)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)