### PR TITLE
harden: CSS URL whitelist, unified CSS attr escaping, shared rejection handler

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/css-url-validator.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/css-url-validator.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedCssUrl } from './css-url-validator';
+
+describe('isAllowedCssUrl (review: whitelist over substring blocklist)', () => {
+    it('allows http/https absolute URLs', () => {
+        expect(isAllowedCssUrl('http://example.com/theme.css')).toBe(true);
+        expect(isAllowedCssUrl('https://cdn.example.com/a.css')).toBe(true);
+        expect(isAllowedCssUrl('HTTPS://EXAMPLE.COM/A.CSS')).toBe(true); // scheme case-insensitive
+    });
+
+    it('allows relative paths (no scheme)', () => {
+        expect(isAllowedCssUrl('theme.css')).toBe(true);
+        expect(isAllowedCssUrl('./assets/theme.css')).toBe(true);
+        expect(isAllowedCssUrl('/static/theme.css')).toBe(true);
+        expect(isAllowedCssUrl('../up/theme.css')).toBe(true);
+    });
+
+    it('allows protocol-relative URLs', () => {
+        expect(isAllowedCssUrl('//cdn.example.com/a.css')).toBe(true);
+    });
+
+    it('rejects javascript: / data: / file: / vbscript: schemes', () => {
+        expect(isAllowedCssUrl('javascript:alert(1)')).toBe(false);
+        expect(isAllowedCssUrl('data:text/css,body{}')).toBe(false);
+        expect(isAllowedCssUrl('file:///etc/passwd')).toBe(false);
+        expect(isAllowedCssUrl('vbscript:msgbox')).toBe(false);
+    });
+
+    it('rejects casing-mixed dangerous schemes (blocklist bypass)', () => {
+        expect(isAllowedCssUrl('JavaScript:alert(1)')).toBe(false);
+        expect(isAllowedCssUrl('DATA:text/css,x')).toBe(false);
+    });
+
+    it('rejects null/undefined/empty/whitespace', () => {
+        expect(isAllowedCssUrl(null)).toBe(false);
+        expect(isAllowedCssUrl(undefined)).toBe(false);
+        expect(isAllowedCssUrl('')).toBe(false);
+        expect(isAllowedCssUrl('   ')).toBe(false);
+    });
+
+    it('trims surrounding whitespace before judging the scheme', () => {
+        expect(isAllowedCssUrl('  https://example.com/a.css  ')).toBe(true);
+        expect(isAllowedCssUrl('  javascript:alert(1)')).toBe(false);
+    });
+});

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/css-url-validator.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/css-url-validator.ts
@@ -1,0 +1,42 @@
+/**
+ * overrideCssUrl 白名单校验（纯逻辑，便于单测）。
+ *
+ * 背景（review 发现）：原校验用子串黑名单（包含 'javascript:'/'data:' 就拒绝），可被大小写
+ * 混写、换行等绕过。改为白名单：解析 URL，只允许 http/https 绝对地址与相对路径，其余一律拒绝。
+ * 即便该属性由 Java 后端控制（风险较低），白名单也提供纵深防御。
+ */
+
+/**
+ * 判断 overrideCssUrl 是否允许作为外部样式表加载。
+ *
+ * 允许：
+ * - http: / https: 绝对 URL
+ * - 相对路径（无协议，如 ./theme.css、/assets/x.css、theme.css）
+ * 拒绝：
+ * - 含协议但非 http/https（javascript:、data:、file:、vbscript: 等）
+ * - 空白/空串
+ *
+ * @param rawUrl overrideCssUrl 原值
+ * @returns 是否允许加载
+ */
+export function isAllowedCssUrl(rawUrl: string | null | undefined): boolean {
+    if (rawUrl == null) {
+        return false;
+    }
+    const url = rawUrl.trim();
+    if (url === '') {
+        return false;
+    }
+
+    // 探测是否带 scheme：scheme 形如 a-z/数字/+/-/. 开头后接 ':'。
+    // 注意要在去除可能的前导空白后判断，且不能被换行绕过——用从串首开始的严格匹配。
+    const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(url);
+    if (schemeMatch) {
+        const scheme = schemeMatch[1].toLowerCase();
+        return scheme === 'http' || scheme === 'https';
+    }
+
+    // 无 scheme → 视为相对路径，允许。但 protocol-relative（//host/x）也无 scheme，
+    // 浏览器会按当前页协议加载，安全可接受；明确允许。
+    return true;
+}

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -26,6 +26,8 @@ import {
 import { shouldRefreshSourceView } from './source-editing-refresh';
 import { decideDataChange } from './data-change-decision';
 import { replaceObserver, disposeObserver } from './observer-lifecycle';
+import { createRefcount } from './dark-theme-refcount';
+import { isAllowedCssUrl } from './css-url-validator';
 
 // 内置插件
 import CommentPermissionEnforcer from './comment-permission-enforcer';
@@ -1588,9 +1590,8 @@ export class VaadinCKEditor extends LitElement {
     private loadCustomCss(): void {
         if (!this.overrideCssUrl) return;
 
-        // Validate URL: only allow http(s) and relative paths (case-insensitive check)
-        const normalizedUrl = this.overrideCssUrl.trim().toLowerCase();
-        if (normalizedUrl.includes('javascript:') || normalizedUrl.includes('data:')) {
+        // 白名单校验：只允许 http/https 绝对地址与相对路径（review: 子串黑名单可被绕过）
+        if (!isAllowedCssUrl(this.overrideCssUrl)) {
             logger.warn('Rejected overrideCssUrl with unsafe protocol:', this.overrideCssUrl);
             return;
         }
@@ -1939,18 +1940,11 @@ export class VaadinCKEditor extends LitElement {
         logger.debug(' connectedCallback, editorId:', this.editorId);
         this.isDisconnected = false;
 
-        // Suppress CKEditor Pagination plugin internal errors (non-fatal)
-        if (!this.paginationErrorHandler) {
-            this.paginationErrorHandler = (event: PromiseRejectionEvent) => {
-                const err = event.reason;
-                if (err instanceof TypeError &&
-                    err.stack?.includes('PageStarterInfoToPageBreakInfo')) {
-                    event.preventDefault();
-                    logger.debug('Suppressed Pagination plugin internal error:', err.message);
-                }
-            };
-            window.addEventListener('unhandledrejection', this.paginationErrorHandler);
-        }
+        // Suppress CKEditor Pagination plugin internal errors (non-fatal).
+        // review: 单个全局 unhandledrejection listener 跨所有实例共享（带引用计数），
+        // 避免每个编辑器各注册一个、同一个 rejection 触发 N 次冗余回调。
+        VaadinCKEditor.acquirePaginationErrorHandler();
+        this.paginationHandlerAcquired = true;
 
         // Setup scroll handler for sticky panel (must be called on each connection)
         this.setupStickyPanelObserver();
@@ -1962,6 +1956,14 @@ export class VaadinCKEditor extends LitElement {
      */
     private static isSafeCssValue(value: string): boolean {
         return !/[{};]/.test(value);
+    }
+
+    /**
+     * 转义值以安全嵌入双引号 CSS 属性选择器 [attr="..."] 中。
+     * 去除可越出引号上下文的字符：反斜杠、双引号、右方括号（review: editorId 与 buttonName 统一处理）。
+     */
+    private static cssAttrValueSafe(value: string): string {
+        return value.replace(/[\\"\]]/g, '');
     }
 
     /**
@@ -1977,9 +1979,8 @@ export class VaadinCKEditor extends LitElement {
         this.removeToolbarStyles();
 
         const style = this.toolbarStyle;
-        // Escape editorId for safe use in CSS attribute selector
-        const safeEditorId = this.editorId.replace(/[\\"]/g, '');
-        const scope = `vaadin-ckeditor[editor-id="${safeEditorId}"]`;
+        // 统一用 cssAttrValueSafe 转义，防止值越出双引号属性选择器 [attr="..."]（review: 与 buttonName 保持一致）
+        const scope = `vaadin-ckeditor[editor-id="${VaadinCKEditor.cssAttrValueSafe(this.editorId)}"]`;
         const rules: string[] = [];
 
         // Helper to safely add a CSS value (rejects values with injection characters)
@@ -2020,7 +2021,7 @@ export class VaadinCKEditor extends LitElement {
         if (style.buttonStyles) {
             for (const [buttonName, buttonStyle] of Object.entries(style.buttonStyles)) {
                 // Sanitize buttonName to prevent CSS injection via attribute selector
-                const safeName = buttonName.replace(/[\\"\]]/g, '');
+                const safeName = VaadinCKEditor.cssAttrValueSafe(buttonName);
                 if (!safeName) continue;
                 const btnSelector = `${scope} .ck.ck-toolbar .ck-button[data-cke-tooltip-text*="${safeName}"]`;
                 if (buttonStyle.background && safe(buttonStyle.background)) {
@@ -2072,7 +2073,34 @@ export class VaadinCKEditor extends LitElement {
     // CKEditor 5 Pagination plugin has an internal bug in _mapElementPageStarterInfoToPageBreakInfo
     // that throws "Cannot read properties of undefined (reading 'parent')" during page break
     // recalculation after dimension changes. This is non-fatal — the editor works correctly.
-    private paginationErrorHandler: ((event: PromiseRejectionEvent) => void) | null = null;
+    //
+    // review: 改为单个进程级共享 listener + 引用计数，避免每实例各注册一个导致冗余触发。
+    private paginationHandlerAcquired = false;
+    private static paginationRefcount = createRefcount();
+    private static paginationListener: ((event: PromiseRejectionEvent) => void) | null = null;
+
+    private static acquirePaginationErrorHandler(): void {
+        VaadinCKEditor.paginationRefcount = VaadinCKEditor.paginationRefcount.acquire();
+        if (VaadinCKEditor.paginationRefcount.justApplied) {
+            VaadinCKEditor.paginationListener = (event: PromiseRejectionEvent) => {
+                const err = event.reason;
+                if (err instanceof TypeError &&
+                    err.stack?.includes('PageStarterInfoToPageBreakInfo')) {
+                    event.preventDefault();
+                    logger.debug('Suppressed Pagination plugin internal error:', err.message);
+                }
+            };
+            window.addEventListener('unhandledrejection', VaadinCKEditor.paginationListener);
+        }
+    }
+
+    private static releasePaginationErrorHandler(): void {
+        VaadinCKEditor.paginationRefcount = VaadinCKEditor.paginationRefcount.release();
+        if (VaadinCKEditor.paginationRefcount.justRemoved && VaadinCKEditor.paginationListener) {
+            window.removeEventListener('unhandledrejection', VaadinCKEditor.paginationListener);
+            VaadinCKEditor.paginationListener = null;
+        }
+    }
 
     // Sticky panel scroll handler state
     private stickyPanelScrollHandler: (() => void) | null = null;
@@ -2205,10 +2233,10 @@ export class VaadinCKEditor extends LitElement {
         // Clean up theme manager (observers and dark theme)
         this.themeManager.cleanup();
 
-        // Clean up pagination error handler
-        if (this.paginationErrorHandler) {
-            window.removeEventListener('unhandledrejection', this.paginationErrorHandler);
-            this.paginationErrorHandler = null;
+        // Clean up pagination error handler (release shared global listener)
+        if (this.paginationHandlerAcquired) {
+            VaadinCKEditor.releasePaginationErrorHandler();
+            this.paginationHandlerAcquired = false;
         }
 
         // Clean up sticky panel observer


### PR DESCRIPTION
## Summary

Info-level review findings in `vaadin-ckeditor.ts` — defensive hardening (you opted to fix even theoretical risks).

## Changes

1. **(security) CSS URL whitelist** — `overrideCssUrl` validation was a substring blocklist (`contains 'javascript:'/'data:'`) bypassable via casing/newlines. Replaced with a **whitelist**: parse the scheme, allow only `http`/`https` + relative/protocol-relative paths. Extracted to pure `isAllowedCssUrl()`.

2. **(security) Unified CSS attr escaping** — `editorId` and `buttonName` used two slightly different ad-hoc regexes to escape values for a double-quoted attribute selector. Unify via `cssAttrValueSafe()`. (Note: `CSS.escape` is deliberately **not** used — it's for identifiers, not quoted attribute values; the reviewer's suggestion was a misdiagnosis.)

3. **(correctness) Shared `unhandledrejection` handler** — was registered per instance, so one rejection fired N redundant handlers. Convert to a single process-wide listener with a **reference count** (reusing `dark-theme-refcount`): registered on the first connected editor, removed when the last disconnects.

## Tests

`css-url-validator.test.ts` (7): http/https, relative, protocol-relative, rejects js/data/file/vbscript incl. mixed casing, null/empty, whitespace-trim.

## Verification

```
tsc --noEmit → clean
vitest       → 161/161
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)