### PR TITLE
docs: clarify null/exception contracts + unify PaginationMargins visibility

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -268,7 +268,8 @@ public class CKEditorConfig {
             this.left = left;
         }
 
-        ObjectNode toJson() {
+        // review: 统一为 public，与其它内部配置类的 toJson()（HeadingOption/CodeBlockLanguage 等）一致
+        public ObjectNode toJson() {
             ObjectNode obj = createObjectNode();
             if (top != null) obj.put("top", top);
             if (right != null) obj.put("right", right);

--- a/src/main/java/com/wontlost/ckeditor/HotDeployConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/HotDeployConfig.java
@@ -83,6 +83,10 @@ public class HotDeployConfig implements VaadinServiceInitListener {
             return;
         }
 
+        // 双重检查锁定（double-checked locking）：仅首次初始化时进入 synchronized，
+        // 避免每次 serviceInit 都加锁。两处检查都必要——外层检查规避锁开销，
+        // 内层检查防止多线程同时通过外层检查后重复初始化。initialized 必须为 volatile
+        // 以保证可见性与禁止重排序。
         if (!initialized) {
             synchronized (HotDeployConfig.class) {
                 if (!initialized) {

--- a/src/main/java/com/wontlost/ckeditor/handler/ErrorHandler.java
+++ b/src/main/java/com/wontlost/ckeditor/handler/ErrorHandler.java
@@ -69,6 +69,9 @@ public interface ErrorHandler {
      * <p>This method is called <b>before</b> {@code EditorErrorEvent} is fired,
      * providing an opportunity to intercept and handle the error.</p>
      *
+     * <p>异常语义：本方法抛出的异常会被调度器捕获并以 WARNING 级别记录日志，<b>不</b>影响事件传播
+     * （效果等同于返回 {@code false}，仍会触发 {@code EditorErrorEvent}）。抛异常不能用来"吞掉"事件。</p>
+     *
      * @param error error details including error code, message, severity, etc.
      * @return {@code true} if the error is fully handled, stopping propagation (event not fired);
      *         {@code false} if the error is not handled or needs to continue propagating (fires {@code EditorErrorEvent})

--- a/src/main/java/com/wontlost/ckeditor/handler/HtmlSanitizer.java
+++ b/src/main/java/com/wontlost/ckeditor/handler/HtmlSanitizer.java
@@ -122,7 +122,12 @@ public interface HtmlSanitizer {
     /**
      * A no-op sanitizer that passes content through unchanged.
      *
-     * @return a passthrough sanitizer
+     * <p>透传语义：原样返回输入，包括 {@code null}。与 {@link #withPolicy} / {@link #withSafelist}
+     * 不同（后者把 null/空串归一为 {@code ""}）；这是有意为之，以保持 passthrough 的透明性。
+     * 标准调用路径在 {@code ContentManager.getSanitizedValue} 中已先行守卫 null，因此实际不会
+     * 把 null 传入此处。</p>
+     *
+     * @return a passthrough sanitizer that returns its input verbatim (null in, null out)
      */
     static HtmlSanitizer passthrough() {
         return html -> html;

--- a/src/main/java/com/wontlost/ckeditor/internal/ContentManager.java
+++ b/src/main/java/com/wontlost/ckeditor/internal/ContentManager.java
@@ -26,8 +26,12 @@ public class ContentManager {
     /**
      * Get sanitized HTML content.
      *
-     * @param html raw HTML
-     * @return sanitized HTML, or raw content if no sanitizer is set
+     * <p>null 语义：本方法对 null/空串原样透传（null in → null out），不归一为 {@code ""}；
+     * 这与 {@link #getSanitizedHtml}/{@link #sanitizeHtml}/{@link #getPlainText}（对 null 返回 {@code ""}）
+     * 不同，是有意的契约差异——本方法保留输入值的 null 语义。调用方若需要空串，应自行归一。</p>
+     *
+     * @param html raw HTML（可为 null）
+     * @return sanitized HTML；无 sanitizer 时原样返回；null/空串原样返回
      */
     public String getSanitizedValue(String html) {
         if (html == null || html.isEmpty()) {

--- a/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
@@ -1417,4 +1417,19 @@ class CKEditorConfigTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("private");
     }
+
+    // review: PaginationMargins.toJson() 现为 public（与其它内部配置类一致），且序列化正确
+    @Test
+    @DisplayName("PaginationMargins.toJson is public and serializes set margins")
+    void paginationMarginsToJsonPublicAndCorrect() {
+        CKEditorConfig.PaginationMargins margins =
+            new CKEditorConfig.PaginationMargins("10mm", "20mm", "10mm", null);
+
+        ObjectNode json = margins.toJson(); // 此前为 package-private，现可外部调用
+
+        assertThat(json.get("top").asString()).isEqualTo("10mm");
+        assertThat(json.get("right").asString()).isEqualTo("20mm");
+        assertThat(json.get("bottom").asString()).isEqualTo("10mm");
+        assertThat(json.has("left")).isFalse(); // null 不序列化
+    }
 }


### PR DESCRIPTION
## Summary

Info-level Java review findings — doc-only except one visibility widening. Behavior is intentionally unchanged: the adversarial verify pass confirmed that changing the null semantics (e.g. null→"") would break callers relying on the current contract.

## Changes

- **`HtmlSanitizer.passthrough()`** — document the deliberate null-passthrough (null in → null out), distinct from `withPolicy`/`withSafelist`.
- **`ContentManager.getSanitizedValue()`** — document that it preserves null (does NOT normalize to `""`).
- **`ErrorHandler.handleError()`** — document that a thrown exception is logged at WARNING and does NOT stop event propagation.
- **`HotDeployConfig`** — comment the double-checked-locking (why both checks + `volatile`).
- **`CKEditorConfig.PaginationMargins.toJson()`** — widen package-private → `public` to match every other inner config class's `toJson()` (the lone outlier). Purely additive.

## Test (+1)

`PaginationMargins.toJson()` is now publicly callable and serializes set margins (null margin omitted).

## Verification

```
mvn -B clean test → all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)