### PR TITLE
docs: clarify empty-MIME allow-all, best-effort cancel, FilterOptions

### DIFF
--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
@@ -420,6 +420,9 @@ export interface FilterOptions {
      * When true, skips filtering of plugins that require special configuration.
      * Use this when you have properly configured plugins like Minimap or Title.
      *
+     * 受影响的完整插件清单见 `PLUGINS_REQUIRING_CONFIG` 常量；可用
+     * `PluginResolver.requiresConfiguration(name)` 以编程方式判断某插件是否需要配置。
+     *
      * @default false
      */
     allowConfigRequiredPlugins?: boolean;

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/upload-adapter.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/upload-adapter.ts
@@ -129,11 +129,16 @@ export class UploadAdapterManager {
 
     /**
      * Check if a MIME type is allowed for upload.
+     *
+     * 注意（review）：空白名单 = "allow all"（即禁用 MIME 过滤），而非 "reject all"。
+     * 这是有意的"禁用模式"设计，与后端 UploadConfig.validate 一致；前端校验仅为体验优化，
+     * 后端始终对上传做权威校验。
+     *
      * @param mimeType - The MIME type to check
      * @returns true if allowed, false otherwise
      */
     isMimeTypeAllowed(mimeType: string): boolean {
-        // Allow all types if whitelist is empty (disabled)
+        // Allow all types if whitelist is empty (disabled / allow-all mode, see doc above)
         if (this.allowedMimeTypes.size === 0) {
             return true;
         }
@@ -254,6 +259,9 @@ export class UploadAdapterManager {
                             manager.pendingUploads.delete(idToCancel);
                             resolver.reject(new Error('Upload cancelled'));
                         }
+                        // 通知服务端取消上传——尽力而为（best-effort，review）：
+                        // 该 RPC 不重试也不等待确认。若网络异常导致调用失败，前端 promise 已 reject，
+                        // 但服务端任务可能继续执行；服务端有超时保护（默认 6 分钟）兜底，资源不会无限占用。
                         // Notify server to cancel upload (type-safe check)
                         if (manager.server?.cancelUploadFromClient) {
                             manager.server.cancelUploadFromClient(idToCancel);


### PR DESCRIPTION
## Summary

Info-level frontend doc clarifications (comment-only, no behavior change).

## Changes

- **`upload-adapter` `isMimeTypeAllowed`** — document that an empty whitelist = "allow all" (filtering disabled), intentional and consistent with the backend; frontend validation is advisory, backend re-validates authoritatively.
- **`upload-adapter` cancel** — document that server cancellation is best-effort (no retry/ack); the server-side 6-minute timeout bounds resources if the cancel RPC is lost.
- **`plugin-resolver` `FilterOptions.allowConfigRequiredPlugins`** — point to `PLUGINS_REQUIRING_CONFIG` / `requiresConfiguration()` for the affected plugin set.

## Verification

```
tsc --noEmit → clean
vitest       → 154/154
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)