### PR TITLE
test: cover autosave callback + event consistency

### DIFF
--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -333,6 +333,14 @@ public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel 
 
     @ClientCallable
     private void saveEditorData(String data) {
+        saveEditorDataInternal(data);
+    }
+
+    /**
+     * autosave 落盘逻辑（package-private 测试缝隙）：调用回调，捕获其异常并产出成功/失败的
+     * AutosaveEvent。抽出以便在不经过客户端 RPC 的前提下直接测试回调一致性与异常处理（review）。
+     */
+    void saveEditorDataInternal(String data) {
         boolean success = true;
         String errorMessage = null;
 

--- a/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
+++ b/src/test/java/com/wontlost/ckeditor/VaadinCKEditorIntegrationTest.java
@@ -339,6 +339,75 @@ class VaadinCKEditorIntegrationTest {
         }
     }
 
+    // ==================== Autosave Tests ====================
+
+    @Nested
+    @DisplayName("Autosave Tests")
+    class AutosaveTests {
+
+        @Test
+        @DisplayName("autosave callback receives the saved data and fires a success event")
+        void autosaveCallbackReceivesDataAndFiresSuccess() {
+            AtomicReference<String> callbackData = new AtomicReference<>();
+            editor.setAutosaveCallback(callbackData::set);
+
+            AtomicReference<AutosaveEvent> firedEvent = new AtomicReference<>();
+            editor.addAutosaveListener(firedEvent::set);
+
+            editor.saveEditorDataInternal("<p>auto saved</p>");
+
+            // 回调收到正确数据
+            assertEquals("<p>auto saved</p>", callbackData.get());
+            // 触发一次成功的 AutosaveEvent，内容一致
+            assertNotNull(firedEvent.get());
+            assertTrue(firedEvent.get().isSuccess());
+            assertEquals("<p>auto saved</p>", firedEvent.get().getContent());
+            assertNull(firedEvent.get().getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("autosave callback exception fires a failure event with a non-null message")
+        void autosaveCallbackExceptionFiresFailure() {
+            editor.setAutosaveCallback(data -> { throw new RuntimeException("disk full"); });
+
+            AtomicReference<AutosaveEvent> firedEvent = new AtomicReference<>();
+            editor.addAutosaveListener(firedEvent::set);
+
+            editor.saveEditorDataInternal("<p>x</p>");
+
+            assertNotNull(firedEvent.get());
+            assertFalse(firedEvent.get().isSuccess(), "exception in callback → failure event");
+            assertEquals("disk full", firedEvent.get().getErrorMessage());
+        }
+
+        @Test
+        @DisplayName("autosave exception with null message still yields a non-null error message")
+        void autosaveCallbackNullMessageExceptionGetsFallback() {
+            editor.setAutosaveCallback(data -> { throw new RuntimeException(); }); // message == null
+            AtomicReference<AutosaveEvent> firedEvent = new AtomicReference<>();
+            editor.addAutosaveListener(firedEvent::set);
+
+            editor.saveEditorDataInternal("<p>x</p>");
+
+            assertFalse(firedEvent.get().isSuccess());
+            assertNotNull(firedEvent.get().getErrorMessage());
+            assertFalse(firedEvent.get().getErrorMessage().isEmpty());
+        }
+
+        @Test
+        @DisplayName("autosave with no callback still fires a success event")
+        void autosaveNoCallbackStillFiresEvent() {
+            AtomicReference<AutosaveEvent> firedEvent = new AtomicReference<>();
+            editor.addAutosaveListener(firedEvent::set);
+
+            editor.saveEditorDataInternal("<p>no-callback</p>");
+
+            assertNotNull(firedEvent.get(), "AutosaveEvent should fire even without a callback");
+            assertTrue(firedEvent.get().isSuccess());
+            assertEquals("<p>no-callback</p>", firedEvent.get().getContent());
+        }
+    }
+
     // ==================== Content Stats Tests ====================
 
     @Nested


### PR DESCRIPTION
## Summary

Fills the autosave test-gap Info finding. The `saveEditorData → callback → AutosaveEvent` path was untested.

## Change

Extract a package-private `saveEditorDataInternal()` test seam (matching the existing `*Internal` pattern) so the logic runs without a client RPC; the `@ClientCallable saveEditorData` delegates to it. **No behavior change.**

## Tests (+4)

- callback receives saved data → success event with matching content
- callback exception → failure event carrying the message
- callback exception with **null** message → non-null fallback message
- no callback → success event still fires

## Verification

```
mvn -B clean test → 534/534
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)