### PR TITLE
feat: resizable embedded media via setMediaEmbedResizable (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `setCaretToEnd()`, `focusEditor()`. Useful when leading block content (e.g. a
   table letterhead) would otherwise be auto-selected on focus — move the caret
   to the start so nothing is highlighted.
+- Resizable embedded media (issue #71): `CKEditorConfig.setMediaEmbedResizable(true)`
+  enables drag-to-resize handles on embedded media (videos). Backed by CKEditor's
+  `MediaEmbedResize` plugin, which 48.2.0 ships only in the `@ckeditor/ckeditor5-media-embed`
+  subpackage (not the `ckeditor5` umbrella); the frontend loads it on demand from the
+  same-version subpackage when the flag is enabled. Requires `CKEditorPlugin.MEDIA_EMBED`.
 
 ## [5.3.0] - 2026-06-26
 

--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -222,10 +222,37 @@ public class CKEditorConfig {
      * Set media embed configuration
      */
     public CKEditorConfig setMediaEmbed(boolean previewsInData) {
-        ObjectNode mediaObj = createObjectNode();
+        ObjectNode mediaObj = getOrCreateMediaEmbed();
         mediaObj.put("previewsInData", previewsInData);
         configs.put("mediaEmbed", mediaObj);
         return this;
+    }
+
+    /**
+     * 启用/禁用嵌入媒体（视频等）的拖拽缩放（issue #71）。
+     *
+     * <p>启用后，选中嵌入媒体会显示四角缩放手柄，可按比例调整宽度。底层由 CKEditor 的
+     * {@code MediaEmbedResize} 插件实现——该插件在 48.2.0 中未由 umbrella {@code ckeditor5}
+     * 包导出，因此前端会在启用时按需从同版本 {@code @ckeditor/ckeditor5-media-embed} 子包
+     * 动态加载并注册，无需消费端额外配置。缩放数据以 {@code media_resized} class + 内联
+     * width 写入 {@code <figure>}，与 {@code previewsInData} 设置无关。</p>
+     *
+     * @param resizable true 启用拖拽缩放
+     * @return this
+     */
+    public CKEditorConfig setMediaEmbedResizable(boolean resizable) {
+        ObjectNode mediaObj = getOrCreateMediaEmbed();
+        mediaObj.put("resizable", resizable);
+        configs.put("mediaEmbed", mediaObj);
+        return this;
+    }
+
+    private ObjectNode getOrCreateMediaEmbed() {
+        JsonNode existing = configs.get("mediaEmbed");
+        if (existing != null && existing.isObject()) {
+            return (ObjectNode) existing;
+        }
+        return createObjectNode();
     }
 
     /**
@@ -1161,6 +1188,19 @@ public class CKEditorConfig {
         JsonNode node = configs.get("mediaEmbed");
         if (node != null && node.isObject() && node.has("previewsInData")) {
             return node.get("previewsInData").asBoolean();
+        }
+        return false;
+    }
+
+    /**
+     * Check if media embed drag-to-resize is enabled.
+     *
+     * @return true if resizable is enabled, false otherwise
+     */
+    public boolean isMediaEmbedResizable() {
+        JsonNode node = configs.get("mediaEmbed");
+        if (node != null && node.isObject() && node.has("resizable")) {
+            return node.get("resizable").asBoolean();
         }
         return false;
     }

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { shouldLoadMediaEmbedResize } from './media-embed-resize';
+
+describe('shouldLoadMediaEmbedResize (issue #71)', () => {
+    it('returns true when mediaEmbed.resizable === true', () => {
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { resizable: true } })).toBe(true);
+    });
+
+    it('returns true even with other mediaEmbed keys present', () => {
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { previewsInData: true, resizable: true } })).toBe(true);
+    });
+
+    it('returns false when resizable is false', () => {
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { resizable: false } })).toBe(false);
+    });
+
+    it('returns false when resizable is absent', () => {
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { previewsInData: true } })).toBe(false);
+    });
+
+    it('returns false when mediaEmbed is missing', () => {
+        expect(shouldLoadMediaEmbedResize({ toolbar: ['bold'] })).toBe(false);
+    });
+
+    it('returns false for null/undefined/empty config', () => {
+        expect(shouldLoadMediaEmbedResize(null)).toBe(false);
+        expect(shouldLoadMediaEmbedResize(undefined)).toBe(false);
+        expect(shouldLoadMediaEmbedResize({})).toBe(false);
+    });
+
+    it('returns false when resizable is a truthy non-true value (strict equality)', () => {
+        // 仅严格 === true 才加载，避免 'true'/1 等意外值误触发
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { resizable: 'true' } })).toBe(false);
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: { resizable: 1 } })).toBe(false);
+    });
+
+    it('returns false when mediaEmbed is not an object', () => {
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: true })).toBe(false);
+        expect(shouldLoadMediaEmbedResize({ mediaEmbed: 'x' })).toBe(false);
+    });
+});

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
@@ -1,0 +1,36 @@
+/**
+ * 嵌入媒体缩放插件的按需加载（issue #71）。
+ *
+ * CKEditor 48.2.0 的 MediaEmbedResize 是免费 GPL 插件，但未由 umbrella `ckeditor5` 包导出，
+ * 只在同版本 `@ckeditor/ckeditor5-media-embed` 子包里。这里把"是否需要加载"的判断抽成纯函数
+ * 便于单测，并提供一个动态 import 的加载器——仅在用户启用 setMediaEmbedResizable(true) 时
+ * 才拉取子包，避免无谓打包，也规避静态混用 umbrella+子包的风险。
+ */
+
+/**
+ * 根据 config.mediaEmbed.resizable 判断是否需要加载 MediaEmbedResize 插件。
+ * 仅当 mediaEmbed 为对象且 resizable === true 时返回 true。
+ */
+export function shouldLoadMediaEmbedResize(config: Record<string, unknown> | null | undefined): boolean {
+    if (config == null) {
+        return false;
+    }
+    const mediaEmbed = config.mediaEmbed;
+    if (typeof mediaEmbed !== 'object' || mediaEmbed === null) {
+        return false;
+    }
+    return (mediaEmbed as Record<string, unknown>).resizable === true;
+}
+
+/**
+ * 从同版本子包动态加载 MediaEmbedResize 插件构造器。
+ * 失败时返回 null（调用方据此跳过并可记录告警），不抛出以免阻断编辑器创建。
+ */
+export async function loadMediaEmbedResizePlugin(): Promise<unknown | null> {
+    try {
+        const mod = await import('@ckeditor/ckeditor5-media-embed') as Record<string, unknown>;
+        return mod.MediaEmbedResize ?? null;
+    } catch {
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -28,6 +28,7 @@ import { decideDataChange } from './data-change-decision';
 import { replaceObserver, disposeObserver } from './observer-lifecycle';
 import { createRefcount } from './dark-theme-refcount';
 import { isAllowedCssUrl } from './css-url-validator';
+import { shouldLoadMediaEmbedResize, loadMediaEmbedResizePlugin } from './media-embed-resize';
 
 // 内置插件
 import CommentPermissionEnforcer from './comment-permission-enforcer';
@@ -560,6 +561,18 @@ export class VaadinCKEditor extends LitElement {
         if (this.commentPermissionEnforcerEnabled && this.annotationSidebarEnabled) {
             resolvedPlugins.push(CommentPermissionEnforcer);
             logger.debug('CommentPermissionEnforcer plugin injected');
+        }
+
+        // 嵌入媒体缩放（issue #71）：MediaEmbedResize 不在 umbrella ckeditor5 包，
+        // 启用时从同版本子包按需动态加载并注册。
+        if (shouldLoadMediaEmbedResize(this.config)) {
+            const resizePlugin = await loadMediaEmbedResizePlugin();
+            if (resizePlugin) {
+                resolvedPlugins.push(resizePlugin);
+                logger.debug('MediaEmbedResize plugin injected');
+            } else {
+                logger.warn('MediaEmbedResize requested but could not be loaded from @ckeditor/ckeditor5-media-embed');
+            }
         }
 
         // Get translations for the specified language

--- a/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
@@ -141,6 +141,43 @@ class CKEditorConfigTest {
         assertThat(json.get("mediaEmbed").get("previewsInData").asBoolean()).isTrue();
     }
 
+    // issue #71: media embed drag-to-resize
+    @Test
+    @DisplayName("setMediaEmbedResizable should set the resizable flag")
+    void setMediaEmbedResizableShouldSetFlag() {
+        config.setMediaEmbedResizable(true);
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").get("resizable").asBoolean()).isTrue();
+        assertThat(config.isMediaEmbedResizable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedResizable defaults to false when never set")
+    void isMediaEmbedResizableDefaultsFalse() {
+        assertThat(config.isMediaEmbedResizable()).isFalse();
+        config.setMediaEmbed(true); // mediaEmbed exists but no resizable key
+        assertThat(config.isMediaEmbedResizable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("setMediaEmbed and setMediaEmbedResizable coexist in the same mediaEmbed object")
+    void mediaEmbedAndResizableCoexist() {
+        config.setMediaEmbed(true).setMediaEmbedResizable(true);
+        ObjectNode json = config.toJson();
+
+        // 两个 setter 写入同一个 mediaEmbed 对象，互不覆盖
+        assertThat(json.get("mediaEmbed").get("previewsInData").asBoolean()).isTrue();
+        assertThat(json.get("mediaEmbed").get("resizable").asBoolean()).isTrue();
+
+        // 反向顺序同样保留两者
+        CKEditorConfig c2 = new CKEditorConfig();
+        c2.setMediaEmbedResizable(true).setMediaEmbed(false);
+        ObjectNode j2 = c2.toJson();
+        assertThat(j2.get("mediaEmbed").get("resizable").asBoolean()).isTrue();
+        assertThat(j2.get("mediaEmbed").get("previewsInData").asBoolean()).isFalse();
+    }
+
     @Test
     @DisplayName("setMention should create mention config with feeds")
     void setMentionShouldCreateMentionConfig() {


### PR DESCRIPTION
## Summary

Implements #71 — drag-to-resize handles for embedded media (videos), via CKEditor's `MediaEmbedResize` plugin.

## Validation that corrected the earlier triage

The earlier triage said this wasn't implementable. Re-verified against the docs **and the installed 48.2.0 packages**:
- `MediaEmbedResize` is a **free (GPL) plugin** in 48.2.0 (the "premium" note in CKEditor's docs reflects a *later* version).
- It is **not re-exported by the umbrella `ckeditor5`** (absent from `ckeditor5/dist/ckeditor5.js`) — only in `@ckeditor/ckeditor5-media-embed`, which is present as a **pinned, exact-same-version (48.2.0)** transitive dep. So loading it on demand from that subpackage is safe (no dual-version hazard).

## API

```java
CKEditorConfig config = new CKEditorConfig().setMediaEmbedResizable(true);
VaadinCKEditor editor = VaadinCKEditor.create()
        .addPlugin(CKEditorPlugin.MEDIA_EMBED)   // required
        .withConfig(c -> c.setMediaEmbedResizable(true))
        .withToolbar("mediaEmbed", "|", "bold", "italic")
        .build();
```

`setMediaEmbedResizable` shares the `mediaEmbed` config object with `setMediaEmbed`, so `previewsInData` and `resizable` coexist regardless of call order.

## Implementation

- Pure `shouldLoadMediaEmbedResize(config)` gates on `mediaEmbed.resizable === true`.
- When true, `buildConfig` dynamically `import('@ckeditor/ckeditor5-media-embed')` and registers `MediaEmbedResize` (mirrors the existing `CommentPermissionEnforcer` injection). Load failure is logged, not fatal.

## Tests

- `media-embed-resize.test.ts` (8): strict-true gating, coexistence with other keys, null/non-object/non-true safety.
- `CKEditorConfigTest` (+3): flag serialization, default-false, `setMediaEmbed`/`setMediaEmbedResizable` coexistence (both orders).
- Verified the subpackage's `index.js` actually exports `MediaEmbedResize` (+ `Editing`/`Handles`).

```
mvn -B clean test → 539/539
tsc --noEmit      → clean
vitest            → 169/169
```

The drag-resize UI behavior itself is browser-verified via e2e (as with other component-level features).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)