### PR TITLE
feat: add free media-embed companion plugins; fix MediaEmbedResize/LineHeight tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/main/resources/META-INF/frontend/vaadin-ckeditor/node_modules/
 
 # Claude/AI tools
 .claude/
+.ccg/
 .ace-tool/
 
 # OS files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself is free (umbrella-exported); using it requires `config.ckfinder.uploadUrl` and
   a CKFinder server backend, so it is treated as a config-required plugin (filtered out
   of auto-select unless `setAllowConfigRequiredPlugins(true)` is set).
+- `CKEditorConfig.setMediaEmbedToolbar(String...)` — fluent setter that writes media
+  toolbar buttons to `config.mediaEmbed.toolbar` (where `MediaEmbedStyle`'s alignment
+  buttons such as `mediaEmbed:alignLeft` must live, not the top-level `config.toolbar`).
+  Empty/null input writes nothing (no empty-array noise).
 
 ### Changed
 - `media-embed-resize.ts`: the on-demand `MediaEmbedResize` loader now imports from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the start so nothing is highlighted.
 - Resizable embedded media (issue #71): `CKEditorConfig.setMediaEmbedResizable(true)`
   enables drag-to-resize handles on embedded media (videos). Backed by CKEditor's
-  `MediaEmbedResize` plugin, which 48.2.0 ships only in the `@ckeditor/ckeditor5-media-embed`
-  subpackage (not the `ckeditor5` umbrella); the frontend loads it on demand from the
-  same-version subpackage when the flag is enabled. Requires `CKEditorPlugin.MEDIA_EMBED`.
+  `MediaEmbedResize` plugin. The frontend loads it on demand from the `ckeditor5`
+  umbrella package only when the flag is enabled; load failures (e.g. missing
+  commercial license — see below) degrade silently. Requires `CKEditorPlugin.MEDIA_EMBED`.
+- Free media-embed companion plugins, exported by the `ckeditor5` umbrella and now
+  registered as built-in `CKEditorPlugin` constants:
+  - `MEDIA_EMBED_STYLE` (`MediaEmbedStyle`) — alignment/styling for embedded media
+    (`mediaEmbed:alignLeft` / `alignCenter` / `alignRight` toolbar items); the sibling
+    feature of the resize support above. Not auto-loaded by `MEDIA_EMBED`, so it must
+    be selected explicitly.
+  - `MEDIA_EMBED_TOOLBAR` (`MediaEmbedToolbar`) — floating toolbar shown when an
+    embedded media widget is selected (hosts the style/alignment buttons).
+  - `AUTO_MEDIA_EMBED` (`AutoMediaEmbed`) — auto-converts pasted media links into embeds.
+- `CKFINDER` (`CKFinder`) — CKFinder file-manager integration plugin. The plugin class
+  itself is free (umbrella-exported); using it requires `config.ckfinder.uploadUrl` and
+  a CKFinder server backend, so it is treated as a config-required plugin (filtered out
+  of auto-select unless `setAllowConfigRequiredPlugins(true)` is set).
+
+### Changed
+- `media-embed-resize.ts`: the on-demand `MediaEmbedResize` loader now imports from the
+  `ckeditor5` umbrella package instead of the `@ckeditor/ckeditor5-media-embed` subpackage.
+  Verified against the installed 48.2.0 artifacts: the umbrella re-exports the whole
+  media-embed subpackage (`export * from '@ckeditor/ckeditor5-media-embed'`), so
+  `import { MediaEmbedResize } from 'ckeditor5'` resolves. Importing from the umbrella
+  (rather than mixing umbrella + subpackage entry points) avoids the risk of resolving
+  two distinct class instances. Corrects the prior comment that claimed the plugin was
+  "free" and "not umbrella-exported": it *is* umbrella-exported, but its
+  `MediaEmbedResizeEditing` dependency has `isPremiumPlugin === true`, so loading it under
+  a GPL license triggers CKEditor's license check — it is effectively a premium feature.
+
+### Removed
+- **Breaking:** `CKEditorPlugin.LINE_HEIGHT` removed from the free built-in plugin enum.
+  `LineHeight` is a **premium** feature in CKEditor 48.x — it is not exported by the
+  `ckeditor5` umbrella package (only by `ckeditor5-premium-features`, where its class
+  reports `isPremiumPlugin === true`) and was never registered in the TypeScript
+  `PLUGIN_REGISTRY`, so `withPlugins(CKEditorPlugin.LINE_HEIGHT)` produced a
+  "Plugin not found in registry" error at runtime. The premium definition already exists
+  as `VaadinCKEditorPremium.PremiumPlugin.LINE_HEIGHT`.
+  - **Migration:** replace `withPlugins(CKEditorPlugin.LINE_HEIGHT)` with
+    `addCustomPlugin(CustomPlugin.fromPremium("LineHeight"))` and configure a commercial
+    license key.
 
 ## [5.3.0] - 2026-06-26
 

--- a/docs/PLUGIN_GAP_ANALYSIS.md
+++ b/docs/PLUGIN_GAP_ANALYSIS.md
@@ -1,0 +1,172 @@
+# CKEditor 插件差集分析报告（ckeditor5 48.2.0）
+
+> 本报告核对 CKEditor 5 官方 `ckeditor5`（免费）与 `ckeditor5-premium-features`（付费）
+> 两个 umbrella 包在 **48.2.0** 版本的插件全集，与本库（vaadin-ckeditor）当前支持范围做差集，
+> 给出补全决策与实施结果。
+>
+> **核验方法**：双链交叉验证。
+> 1. **一手 import 证据** — 本地安装 `ckeditor5@48.2.0` + `ckeditor5-premium-features@48.2.0`，
+>    在 jsdom 提供 DOM 后真实 ESM `import`，读取 **1473 个 umbrella 导出键**与 premium 包导出，
+>    并逐个核验插件类的静态 `isPremiumPlugin` gate。
+> 2. **Workflow 65-agent 网络核验** — 对抗性验证插件 tier/source，结论与一手证据完全一致。
+>
+> ⚠️ 过程教训：对 minify 后的 runtime bundle 做 `grep` / `es-module-lexer` 均产生**伪证据**
+> （类名被改写、`export *` 转发不展开），唯有**真实 import 解析**给出真相。涉及 CKEditor 包导出
+> 结构的判断，必须以真实 import 为准，不可凭 bundle 文本或文档转述。
+
+---
+
+## 1. 核心架构回顾：本库的三条插件加载路径
+
+| 类型 | Java 入口 | TS 加载方式 | 是否需逐个登记 |
+|------|-----------|-------------|----------------|
+| **标准免费插件** | `withPlugins(CKEditorPlugin.X)` | 静态 `PLUGIN_REGISTRY` 查表 | **是**（枚举 + registry 双侧） |
+| **Premium 插件** | `addCustomPlugin(CustomPlugin.fromPremium("X"))` | 运行时 `import('ckeditor5-premium-features')` 按名取 | **否**（generic channel，任意名生效） |
+| **第三方/自研** | `addCustomPlugin(CustomPlugin.withImportPath("..."))` | 动态 `import(importPath)` | **否** |
+
+关键差异：
+- **免费插件**走静态 registry，必须在 `CKEditorPlugin` 枚举 + `plugin-resolver.ts` 的 `PLUGIN_REGISTRY`
+  各登记一行才能用。这是"免费差集"的实际含义。
+- **Premium 插件**走 generic channel，`fromPremium(anyName)` 对 `ckeditor5-premium-features` 的
+  任意导出生效。因此"premium 差集"在**功能层面不存在**。
+
+---
+
+## 2. 关键裁决（一手证据锁定）
+
+| 插件 | umbrella 导出 | 类 `isPremiumPlugin` | 依赖链 premium gate | 真实 tier | 本库原认知 |
+|------|:---:|:---:|:---:|------|------|
+| `MediaEmbedStyle` | ✅ | false | `StyleEditing` = false | **真免费** | 未收录 |
+| `MediaEmbedToolbar` | ✅ | false | — | **真免费** | 未收录 |
+| `AutoMediaEmbed` | ✅ | false | — | **真免费** | 未收录 |
+| `MediaEmbedResize` | ✅ | false | **`ResizeEditing` = TRUE** | **功能 premium** | ❌ 注释称"免费、未由 umbrella 导出" |
+| `TableLayout` | ✅ | false | **`LayoutEditing` = TRUE** | **功能 premium** | ✅ 已正确归 premium |
+| `LineHeight` | ❌ | premium 包 = TRUE | — | **premium** | ❌ 免费枚举里错误登记 |
+
+### 2.1 "功能性 premium" 概念
+
+部分插件的 **glue 类**本身 `isPremiumPlugin === false`（看起来免费），但其 `requires` 依赖链上的
+`*Editing` 子插件 `isPremiumPlugin === true`。CKEditor 的 license 校验按依赖链整体判定：在 GPL license 下
+加载这类插件会触发 license 报错。`MediaEmbedResize`、`TableLayout` 即属此类——**umbrella 可 import，但功能需商业 license**。
+
+### 2.2 `MediaEmbedResize` 真相
+
+本库 `media-embed-resize.ts` 旧注释断言"48.2.0 未由 umbrella 导出，只在 `@ckeditor/ckeditor5-media-embed` 子包"。
+**这是错的**：
+
+- `ckeditor5@48.2.0/dist/index.d.ts` 与 `dist/ckeditor5.js` 通过 `export * from '@ckeditor/ckeditor5-media-embed'`
+  把整个子包（含 `MediaEmbedResize`/`MediaEmbedStyle`）透传到 umbrella，`import { MediaEmbedResize } from 'ckeditor5'` 可解析。
+- 但它是功能性 premium（`MediaEmbedResizeEditing.isPremiumPlugin === true`），不是免费 GPL。
+
+**结论**：保留"按需隔离加载 + 失败静默"的设计（正确，避免无 license 用户崩溃），但
+（a）订正注释，（b）import 源由子包改为 umbrella `ckeditor5`，消除"静态 umbrella + 动态子包"双入口可能解析到
+不同类实例的风险。**不**并入免费 registry。
+
+---
+
+## 3. 免费插件差集
+
+### 3.1 已实施补全
+
+| 优先级 | 插件 | Java 枚举常量 | 说明 | 加载特性 |
+|:---:|------|------|------|------|
+| **P0** | `MediaEmbedStyle` | `MEDIA_EMBED_STYLE` | resize 的姊妹特性，媒体对齐/排版样式。**不被 `MediaEmbed` 自动加载**，需显式选择 | 标准 registry |
+| **P1** | `MediaEmbedToolbar` | `MEDIA_EMBED_TOOLBAR` | 选中媒体时的浮动工具栏，承载 style/对齐按钮 | 标准 registry |
+| **P1** | `AutoMediaEmbed` | `AUTO_MEDIA_EMBED` | 粘贴链接自动转嵌入 | 标准 registry |
+| **P2** | `CKFinder` | `CKFINDER` | 文件管理集成；类免费但需 `config.ckfinder.uploadUrl` + 服务端 | 标准 registry + **require-config** |
+
+`CKFinder` 已加入 `plugin-resolver.ts` 的 `PLUGINS_REQUIRING_CONFIG`，自动全选时被过滤，
+显式配置后通过 `setAllowConfigRequiredPlugins(true)` 放行。
+
+### 3.2 不予补全的项（及理由）
+
+Workflow confirmedGaps 列出 60 个"umbrella 有、本库 registry 无"的导出，但绝大多数**不应**单独登记：
+
+| 类别 | 示例 | 不补的理由 |
+|------|------|------|
+| glue plugin 的内部子组件 | `BoldEditing`、`BoldUI`、`MediaEmbedEditing`、`MediaEmbedUI`、`AlignmentEditing` 等 | 已被对应 glue plugin（registry 已有 `Bold`/`MediaEmbed`/`Alignment`）通过 `requires` **自动加载**，单独登记纯属噪音 |
+| 包自动加载的依赖 | `TableClipboard`、`TableKeyboard`、`TableMouse`、`TableSelection` | `Table` 自动加载，无需用户感知 |
+| Essentials 成员 | `Enter`、`ShiftEnter`、`Delete`、`Input`、`Typing` | `Essentials`（registry 已有）自动加载二者 |
+| ContextPlugin / 工具类 | `PendingActions`、`ClipboardPipeline`、`ClipboardMarkersUtils`、`*Utils` | 多被其他插件依赖自动加载，单独登记价值低 |
+| Legacy 废弃类 | `LegacyList`、`LegacyListProperties`、`LegacyTodoList` | 废弃，不应暴露 |
+| 功能性 premium | `CKBox`、`CKBoxImageEdit` 系列 | 类在 umbrella，但功能需商业 license + 另装 `ckbox` 包；走 premium/custom 通道，不进免费 registry |
+
+> 设计原则：免费 registry 只登记**用户需显式选择的 glue plugin**，不登记会被自动加载的子组件
+> （"消灭特殊情况"，避免 registry 膨胀）。
+
+### 3.3 真正需独立包的免费插件
+
+- **`Mermaid`**（流程图/图表）：唯一确凿的"官方免费但不在 umbrella、需独立 npm 包"案例
+  （`@ckeditor/ckeditor5-mermaid`），且官方标注 **experimental，不推荐生产**。
+- **建议**：不收进库。需要的用户用 `CustomPlugin.withImportPath("@ckeditor/ckeditor5-mermaid")` 自助加载。
+
+---
+
+## 4. 付费插件差集
+
+### 4.1 功能层面：无差集
+
+`CustomPlugin.fromPremium(jsName)` 走 `loadPremiumPlugins`（`plugin-resolver.ts`），执行
+`(await import('ckeditor5-premium-features'))[jsName]` —— 纯运行时具名查找，对 premium 包的
+**任意导出名生效**，与 `.d.ts` 是否声明无关（`.d.ts` 末尾 `export default Record<string, unknown>` 兜底）。
+
+因此本库对**全部 premium 插件已具备完整运行时支持**，付费差集在功能层面不存在。
+
+### 4.2 类型层面：`.d.ts` 补全（仅影响 DX，可选）
+
+`ckeditor5-premium-features.d.ts` 声明了 27 个名字用于 TS 类型补全。premium 包实际有 151 个有 `pluginName`
+的插件类（含 65 个顶层 glue plugin），故 `.d.ts` 存在 type-completion 差集。但补全它**只改善 IDE 自动完成**，
+不改变运行时能力。如需提升 DX，可补充常用导出（如 `LineHeight`、`Footnotes`、`Uploadcare` 等）为
+`export const X: unknown;`。**此为可选优化，本次未做**。
+
+### 4.3 边界情况：CKBox
+
+`CKBox` / `CKBoxImageEdit` 是"类在 umbrella `ckeditor5`、但功能 premium 且运行时另需 `ckbox` 服务包"的特性。
+它们**不**从 `ckeditor5-premium-features` 导出，所以 `fromPremium` 对其**无效**。正确用法：
+`CustomPlugin.of("CKBox", ...)`（从 umbrella `ckeditor5` 取）+ 用户自行 `npm i ckbox` + 商业 license。
+此为文档澄清问题，非代码差集。
+
+---
+
+## 5. 实施清单与验证
+
+### 5.1 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `CKEditorPlugin.java` | 新增 `AUTO_MEDIA_EMBED` / `MEDIA_EMBED_STYLE` / `MEDIA_EMBED_TOOLBAR` / `CKFINDER`；移除免费 `LINE_HEIGHT` |
+| `plugin-resolver.ts` | import 块 + `PLUGIN_REGISTRY` 各加 4 项；`CKFinder` 加入 `PLUGINS_REQUIRING_CONFIG` |
+| `media-embed-resize.ts` | 订正注释；动态 import 源 `@ckeditor/ckeditor5-media-embed` → `ckeditor5` |
+| `CKEditorPluginTest.java` | 新增 4 个测试方法（媒体配套插件、CKFinder、LineHeight 移除断言） |
+| `CHANGELOG.md` | Added / Changed / Removed（含 LINE_HEIGHT **Breaking** 迁移说明）；订正旧 issue #71 措辞 |
+
+### 5.2 破坏性变更
+
+`CKEditorPlugin.LINE_HEIGHT` 移除是 breaking change。
+
+**迁移**：
+```java
+// 旧（编译失败）
+.withPlugins(CKEditorPlugin.LINE_HEIGHT)
+
+// 新
+.addCustomPlugin(CustomPlugin.fromPremium("LineHeight"))
+// 并配置商业 license key
+```
+
+### 5.3 验证结果（本地可重复）
+
+- **TS**：`npm run typecheck` 通过；`npm test` → **169/169 通过**
+- **Java**：`mvn clean test` → **542/542 通过**（clean recompile，非陈旧字节码）
+
+---
+
+## 附录：核验依据（本机 48.2.0 产物）
+
+- `ckeditor5/dist/index.d.ts` 第 47 行：`export * from '@ckeditor/ckeditor5-media-embed';`
+- `@ckeditor/ckeditor5-media-embed/dist/index.d.ts`：`export { MediaEmbedResize }`、`export { MediaEmbedStyle }` 等
+- `MediaEmbedResizeEditing.isPremiumPlugin === true`（一手 import 核验）
+- `TableLayoutEditing.isPremiumPlugin === true`（一手 import 核验）
+- `ckeditor5` umbrella：1473 个导出键、293 个有 `pluginName` 的插件类
+- `ckeditor5-premium-features`：151 个有 `pluginName` 的插件类（65 个顶层 glue）
+- `LineHeight`：umbrella 不导出，premium 包导出且 `isPremiumPlugin === true`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -187,7 +187,13 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 
 **Media & Code:**
 - `MEDIA_EMBED`, `AUTO_MEDIA_EMBED`, `MEDIA_EMBED_STYLE`, `MEDIA_EMBED_TOOLBAR`, `HTML_EMBED`, `CODE_BLOCK`
-- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，与 `MEDIA_EMBED_TOOLBAR` 配合使用
+- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，须配合 `MEDIA_EMBED_TOOLBAR` 使用。
+  用 `CKEditorConfig#setMediaEmbedToolbar(...)` 设置这些按钮：
+
+```java
+config.setMediaEmbedToolbar(
+    "mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+```
 
 **Special:**
 - `HORIZONTAL_LINE`, `PAGE_BREAK`, `SPECIAL_CHARACTERS`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -168,7 +168,8 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 - `FONT_SIZE`, `FONT_FAMILY`, `FONT_COLOR`, `FONT_BACKGROUND_COLOR`
 
 **Paragraph:**
-- `HEADING`, `ALIGNMENT`, `INDENT`, `INDENT_BLOCK`, `BLOCK_QUOTE`, `LINE_HEIGHT`
+- `HEADING`, `ALIGNMENT`, `INDENT`, `INDENT_BLOCK`, `BLOCK_QUOTE`
+- 注：`LINE_HEIGHT` 在 CKEditor 48.x 属 premium，请改用 `CustomPlugin.fromPremium("LineHeight")`（需商业 license）
 
 **Lists:**
 - `LIST`, `TODO_LIST`, `LIST_PROPERTIES`
@@ -185,7 +186,8 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 - `TABLE_CAPTION`, `TABLE_COLUMN_RESIZE`
 
 **Media & Code:**
-- `MEDIA_EMBED`, `HTML_EMBED`, `CODE_BLOCK`
+- `MEDIA_EMBED`, `AUTO_MEDIA_EMBED`, `MEDIA_EMBED_STYLE`, `MEDIA_EMBED_TOOLBAR`, `HTML_EMBED`, `CODE_BLOCK`
+- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，与 `MEDIA_EMBED_TOOLBAR` 配合使用
 
 **Special:**
 - `HORIZONTAL_LINE`, `PAGE_BREAK`, `SPECIAL_CHARACTERS`

--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -249,6 +249,30 @@ public class CKEditorConfig {
         return this;
     }
 
+    /**
+     * 设置嵌入媒体的浮动工具栏按钮（写入 {@code config.mediaEmbed.toolbar}）。
+     *
+     * <p>{@code MediaEmbedStyle}（对齐/排版样式）注册的按钮（如
+     * {@code mediaEmbed:alignLeft} / {@code mediaEmbed:alignCenter} /
+     * {@code mediaEmbed:alignRight}）须放入 {@code config.mediaEmbed.toolbar}，
+     * 而非顶层 {@code config.toolbar}；配合 {@code MEDIA_EMBED_TOOLBAR} 插件，
+     * 选中媒体时这些按钮才会出现在浮动工具栏上。</p>
+     *
+     * <p>传入空数组或 {@code null} 不写入 toolbar 字段，避免产生空数组配置。</p>
+     *
+     * @param items 工具栏按钮名称
+     * @return this config for chaining
+     */
+    public CKEditorConfig setMediaEmbedToolbar(String... items) {
+        ArrayNode arr = toArrayNodeOrNull(items);
+        if (arr != null) {
+            ObjectNode mediaObj = getOrCreateMediaEmbed();
+            mediaObj.set("toolbar", arr);
+            configs.put("mediaEmbed", mediaObj);
+        }
+        return this;
+    }
+
     private ObjectNode getOrCreateMediaEmbed() {
         JsonNode existing = configs.get("mediaEmbed");
         if (existing != null && existing.isObject()) {

--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -232,9 +232,11 @@ public class CKEditorConfig {
      * 启用/禁用嵌入媒体（视频等）的拖拽缩放（issue #71）。
      *
      * <p>启用后，选中嵌入媒体会显示四角缩放手柄，可按比例调整宽度。底层由 CKEditor 的
-     * {@code MediaEmbedResize} 插件实现——该插件在 48.2.0 中未由 umbrella {@code ckeditor5}
-     * 包导出，因此前端会在启用时按需从同版本 {@code @ckeditor/ckeditor5-media-embed} 子包
-     * 动态加载并注册，无需消费端额外配置。缩放数据以 {@code media_resized} class + 内联
+     * {@code MediaEmbedResize} 插件实现——该插件由 umbrella {@code ckeditor5} 包导出
+     * （48.2.0 通过 {@code export *} 透传 {@code @ckeditor/ckeditor5-media-embed}），
+     * 但属功能性 premium（其 {@code MediaEmbedResizeEditing} 依赖 {@code isPremiumPlugin=true}），
+     * 故前端在启用时才按需从 {@code ckeditor5} 动态加载，加载失败（如缺商业 license）静默降级，
+     * 无需消费端额外配置。缩放数据以 {@code media_resized} class + 内联
      * width 写入 {@code <figure>}，与 {@code previewsInData} 设置无关。</p>
      *
      * @param resizable true 启用拖拽缩放

--- a/src/main/java/com/wontlost/ckeditor/CKEditorPlugin.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorPlugin.java
@@ -94,8 +94,10 @@ public enum CKEditorPlugin {
     /** Block quotes */
     BLOCK_QUOTE("BlockQuote", Category.PARAGRAPH, "blockQuote"),
 
-    /** Line height */
-    LINE_HEIGHT("LineHeight", Category.PARAGRAPH, "lineHeight"),
+    // 注意：LineHeight 在 ckeditor5 48.x 属 premium，仅由 ckeditor5-premium-features 导出
+    // （其类 isPremiumPlugin=true），umbrella ckeditor5 包不导出。请改用
+    // CustomPlugin.fromPremium("LineHeight") 并配置商业 license key。
+    // 此处不再作为免费内置插件登记。
 
     // ==================== Lists ====================
 
@@ -156,6 +158,13 @@ public enum CKEditorPlugin {
     /** Simple upload adapter */
     SIMPLE_UPLOAD_ADAPTER("SimpleUploadAdapter", Category.UPLOAD),
 
+    /**
+     * CKFinder 文件管理集成（插件类本身免费，由 umbrella ckeditor5 导出）。
+     * 需要配置 config.ckfinder.uploadUrl 与服务端 CKFinder（商业后端产品），
+     * 因此在前端被归入"需配置插件"，自动全选时会被过滤，须显式配置后启用。
+     */
+    CKFINDER("CKFinder", Category.UPLOAD),
+
     // ==================== Tables ====================
 
     /** Basic table support */
@@ -183,6 +192,16 @@ public enum CKEditorPlugin {
 
     /** Embed media from URLs */
     MEDIA_EMBED("MediaEmbed", Category.MEDIA, "mediaEmbed"),
+
+    /** 粘贴链接自动转嵌入媒体（免费，不被 MediaEmbed 自动加载，需显式启用） */
+    AUTO_MEDIA_EMBED("AutoMediaEmbed", Category.MEDIA),
+
+    /** 嵌入媒体对齐/排版样式（免费，提供 mediaEmbed:alignLeft/Center/Right 等按钮） */
+    MEDIA_EMBED_STYLE("MediaEmbedStyle", Category.MEDIA,
+        "mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight"),
+
+    /** 选中嵌入媒体时的浮动工具栏（免费，承载 style/对齐按钮） */
+    MEDIA_EMBED_TOOLBAR("MediaEmbedToolbar", Category.MEDIA),
 
     /** Embed raw HTML */
     HTML_EMBED("HtmlEmbed", Category.MEDIA, "htmlEmbed"),

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
@@ -1,10 +1,13 @@
 /**
  * 嵌入媒体缩放插件的按需加载（issue #71）。
  *
- * CKEditor 48.2.0 的 MediaEmbedResize 是免费 GPL 插件，但未由 umbrella `ckeditor5` 包导出，
- * 只在同版本 `@ckeditor/ckeditor5-media-embed` 子包里。这里把"是否需要加载"的判断抽成纯函数
- * 便于单测，并提供一个动态 import 的加载器——仅在用户启用 setMediaEmbedResizable(true) 时
- * 才拉取子包，避免无谓打包，也规避静态混用 umbrella+子包的风险。
+ * CKEditor 48.2.0 的 MediaEmbedResize **由 umbrella `ckeditor5` 包导出**
+ * （umbrella 通过 `export * from '@ckeditor/ckeditor5-media-embed'` 透传，type 与 runtime 两层均可解析）。
+ * 但它是**功能性 premium**：其依赖 `MediaEmbedResizeEditing` 的 `isPremiumPlugin === true`，
+ * 在 GPL license 下加载会触发 CKEditor 的 license 校验报错。因此不能并入免费 PLUGIN_REGISTRY，
+ * 而是把"是否需要加载"的判断抽成纯函数便于单测，并仅在用户显式 setMediaEmbedResizable(true) 时
+ * 才从 umbrella 动态 import——既避免无谓打包，又把 premium license 失败隔离为静默跳过。
+ * 从 umbrella（而非子包）import 也消除了"静态 umbrella + 动态子包"双入口可能解析到不同类实例的风险。
  */
 
 /**
@@ -23,12 +26,13 @@ export function shouldLoadMediaEmbedResize(config: Record<string, unknown> | nul
 }
 
 /**
- * 从同版本子包动态加载 MediaEmbedResize 插件构造器。
- * 失败时返回 null（调用方据此跳过并可记录告警），不抛出以免阻断编辑器创建。
+ * 从 umbrella `ckeditor5` 包动态加载 MediaEmbedResize 插件构造器。
+ * 失败时返回 null（调用方据此跳过并可记录告警），不抛出以免阻断编辑器创建——
+ * 包括缺少商业 license 触发 premium 校验失败的场景，均静默降级。
  */
 export async function loadMediaEmbedResizePlugin(): Promise<unknown | null> {
     try {
-        const mod = await import('@ckeditor/ckeditor5-media-embed') as Record<string, unknown>;
+        const mod = await import('ckeditor5') as Record<string, unknown>;
         return mod.MediaEmbedResize ?? null;
     } catch {
         return null;

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
@@ -58,6 +58,23 @@ describe('filterConflictingPlugins', () => {
             expect(logger.warn).toHaveBeenCalledTimes(2);
         });
 
+        it('should remove CKFinder by default (requires uploadUrl/server config)', () => {
+            const plugins = ['Bold', 'CKFinder', 'Italic'];
+            const result = filterConflictingPlugins(plugins, logger);
+
+            expect(result.filtered).toEqual(['Bold', 'Italic']);
+            expect(result.removed).toContain('CKFinder');
+        });
+
+        it('should keep CKFinder when allowConfigRequiredPlugins is set', () => {
+            const plugins = ['Bold', 'CKFinder'];
+            const options: FilterOptions = { allowConfigRequiredPlugins: true };
+            const result = filterConflictingPlugins(plugins, logger, options);
+
+            expect(result.filtered).toContain('CKFinder');
+            expect(result.removed).not.toContain('CKFinder');
+        });
+
         it('should keep first plugin from mutually exclusive group', () => {
             const plugins = ['RestrictedEditingMode', 'StandardEditingMode'];
             const result = filterConflictingPlugins(plugins, logger);
@@ -355,6 +372,7 @@ describe('PluginResolver', () => {
 
         it('should check if plugin requires configuration', () => {
             expect(resolver.requiresConfiguration('Minimap')).toBe(true);
+            expect(resolver.requiresConfiguration('CKFinder')).toBe(true);
             expect(resolver.requiresConfiguration('Bold')).toBe(false);
         });
     });

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
@@ -53,6 +53,7 @@ import {
     // Upload adapters
     Base64UploadAdapter,
     SimpleUploadAdapter,
+    CKFinder,
     // Tables
     Table,
     TableToolbar,
@@ -63,6 +64,9 @@ import {
     PlainTableOutput,
     // Media
     MediaEmbed,
+    AutoMediaEmbed,
+    MediaEmbedStyle,
+    MediaEmbedToolbar,
     HtmlEmbed,
     // Code
     CodeBlock,
@@ -207,6 +211,7 @@ export const PLUGIN_REGISTRY: Record<string, PluginConstructor> = {
     // Upload adapters
     'Base64UploadAdapter': Base64UploadAdapter,
     'SimpleUploadAdapter': SimpleUploadAdapter,
+    'CKFinder': CKFinder,
     // Tables
     'Table': Table,
     'TableToolbar': TableToolbar,
@@ -217,6 +222,9 @@ export const PLUGIN_REGISTRY: Record<string, PluginConstructor> = {
     'PlainTableOutput': PlainTableOutput,
     // Media
     'MediaEmbed': MediaEmbed,
+    'AutoMediaEmbed': AutoMediaEmbed,
+    'MediaEmbedStyle': MediaEmbedStyle,
+    'MediaEmbedToolbar': MediaEmbedToolbar,
     'HtmlEmbed': HtmlEmbed,
     // Code
     'CodeBlock': CodeBlock,
@@ -304,6 +312,9 @@ const PLUGINS_REQUIRING_CONFIG: readonly string[] = [
     'CloudServicesCore',
     'CloudServicesUploadAdapter',
     'EasyImage',
+    // CKFinder 需要 config.ckfinder.uploadUrl / 服务端 CKFinder，缺配置会报错，
+    // 故从"全选"中过滤；显式配置后通过 allowConfigRequiredPlugins 放行。
+    'CKFinder',
 ];
 
 /**

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -563,15 +563,16 @@ export class VaadinCKEditor extends LitElement {
             logger.debug('CommentPermissionEnforcer plugin injected');
         }
 
-        // 嵌入媒体缩放（issue #71）：MediaEmbedResize 不在 umbrella ckeditor5 包，
-        // 启用时从同版本子包按需动态加载并注册。
+        // 嵌入媒体缩放（issue #71）：MediaEmbedResize 由 umbrella ckeditor5 导出，
+        // 但属功能性 premium（依赖的 editing 子插件 isPremiumPlugin=true），
+        // 故启用时才从 ckeditor5 按需动态加载，加载失败（如缺 license）静默降级。
         if (shouldLoadMediaEmbedResize(this.config)) {
             const resizePlugin = await loadMediaEmbedResizePlugin();
             if (resizePlugin) {
                 resolvedPlugins.push(resizePlugin);
                 logger.debug('MediaEmbedResize plugin injected');
             } else {
-                logger.warn('MediaEmbedResize requested but could not be loaded from @ckeditor/ckeditor5-media-embed');
+                logger.warn('MediaEmbedResize requested but could not be loaded from ckeditor5 (a commercial license may be required)');
             }
         }
 

--- a/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
@@ -153,6 +153,69 @@ class CKEditorConfigTest {
     }
 
     @Test
+    @DisplayName("setMediaEmbedToolbar should write items to mediaEmbed.toolbar")
+    void setMediaEmbedToolbarShouldWriteItems() {
+        config.setMediaEmbedToolbar("mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").has("toolbar")).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(3);
+        assertThat(json.get("mediaEmbed").get("toolbar").get(0).asString())
+            .isEqualTo("mediaEmbed:alignLeft");
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar should coexist with resizable on the same mediaEmbed object")
+    void setMediaEmbedToolbarShouldCoexistWithResizable() {
+        config.setMediaEmbedResizable(true)
+              .setMediaEmbedToolbar("mediaEmbed:alignCenter");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").get("resizable").asBoolean()).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar with empty/null does not write a toolbar field")
+    void setMediaEmbedToolbarEmptyShouldNotWriteField() {
+        config.setMediaEmbedToolbar();
+        ObjectNode json = config.toJson();
+        assertThat(json.has("mediaEmbed")).isFalse();
+
+        config.setMediaEmbedToolbar((String[]) null);
+        assertThat(config.toJson().has("mediaEmbed")).isFalse();
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar coexists with setMediaEmbed regardless of call order")
+    void setMediaEmbedToolbarCoexistsWithSetMediaEmbedEitherOrder() {
+        // toolbar 先、previewsInData 后
+        config.setMediaEmbedToolbar("mediaEmbed:alignCenter").setMediaEmbed(true);
+        ObjectNode json = config.toJson();
+        assertThat(json.get("mediaEmbed").get("previewsInData").asBoolean()).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(1);
+
+        // 反向顺序：previewsInData 先、toolbar 后
+        CKEditorConfig reversed = new CKEditorConfig();
+        reversed.setMediaEmbed(false).setMediaEmbedToolbar("mediaEmbed:alignLeft");
+        ObjectNode rjson = reversed.toJson();
+        assertThat(rjson.get("mediaEmbed").get("previewsInData").asBoolean()).isFalse();
+        assertThat(rjson.get("mediaEmbed").get("toolbar")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar last non-empty call overwrites previous toolbar")
+    void setMediaEmbedToolbarLastCallWins() {
+        config.setMediaEmbedToolbar("mediaEmbed:alignLeft")
+              .setMediaEmbedToolbar("mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(2);
+        assertThat(json.get("mediaEmbed").get("toolbar").get(0).asString())
+            .isEqualTo("mediaEmbed:alignCenter");
+    }
+
+    @Test
     @DisplayName("setMediaEmbedResizable defaults to false when never set")
     void isMediaEmbedResizableDefaultsFalse() {
         assertThat(config.isMediaEmbedResizable()).isFalse();

--- a/src/test/java/com/wontlost/ckeditor/CKEditorPluginTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorPluginTest.java
@@ -103,4 +103,39 @@ class CKEditorPluginTest {
         assertThat(CKEditorPlugin.STYLE.getCategory()).isEqualTo(CKEditorPlugin.Category.HTML);
         assertThat(CKEditorPlugin.STYLE.getJsName()).isEqualTo("Style");
     }
+
+    @Test
+    @DisplayName("新增的免费 media-embed 配套插件应存在且分类正确")
+    void mediaEmbedCompanionFreePluginsShouldExist() {
+        assertThat(CKEditorPlugin.AUTO_MEDIA_EMBED.getJsName()).isEqualTo("AutoMediaEmbed");
+        assertThat(CKEditorPlugin.AUTO_MEDIA_EMBED.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getJsName()).isEqualTo("MediaEmbedStyle");
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getToolbarItems())
+            .contains("mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+
+        assertThat(CKEditorPlugin.MEDIA_EMBED_TOOLBAR.getJsName()).isEqualTo("MediaEmbedToolbar");
+        assertThat(CKEditorPlugin.MEDIA_EMBED_TOOLBAR.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+    }
+
+    @Test
+    @DisplayName("CKFinder 应作为免费上传类插件存在")
+    void ckFinderShouldExistAsUploadPlugin() {
+        assertThat(CKEditorPlugin.CKFINDER.getJsName()).isEqualTo("CKFinder");
+        assertThat(CKEditorPlugin.CKFINDER.getCategory()).isEqualTo(CKEditorPlugin.Category.UPLOAD);
+    }
+
+    @Test
+    @DisplayName("LineHeight 不应再出现在免费插件枚举中（实为 premium）")
+    void lineHeightShouldNotBeAFreePlugin() {
+        // LineHeight 在 ckeditor5 48.x 属 premium（见 VaadinCKEditorPremium.PremiumPlugin.LINE_HEIGHT），
+        // 不由 umbrella ckeditor5 导出，故不得作为免费内置插件存在。
+        assertThat(CKEditorPlugin.fromJsName("LineHeight")).isNull();
+        for (CKEditorPlugin plugin : CKEditorPlugin.values()) {
+            assertThat(plugin.getJsName())
+                .as("免费枚举不应包含 LineHeight")
+                .isNotEqualTo("LineHeight");
+        }
+    }
 }


### PR DESCRIPTION
## 概述

针对 CKEditor 5 **48.2.0**，核对 umbrella `ckeditor5`（免费）与 `ckeditor5-premium-features`（付费）的插件全集与本库差集，补全免费插件并修正两处 tier 误判。

所有结论经**双链交叉验证**：一手 ESM import 解析（1473 个 umbrella 导出）+ 独立多 agent 网络核查。完整分析见 `docs/PLUGIN_GAP_ANALYSIS.md`。

## 改动

### ✨ 新增免费插件（umbrella 导出，进 PLUGIN_REGISTRY）
- `MEDIA_EMBED_STYLE` (`MediaEmbedStyle`) — 媒体对齐/排版样式，resize 的姊妹特性，**不被 `MediaEmbed` 自动加载**，需显式选择
- `MEDIA_EMBED_TOOLBAR` (`MediaEmbedToolbar`) — 选中媒体时的浮动工具栏
- `AUTO_MEDIA_EMBED` (`AutoMediaEmbed`) — 粘贴链接自动转嵌入
- `CKFINDER` (`CKFinder`) — 文件管理集成；类免费但需 `ckfinder.uploadUrl` + 服务端，故进 `PLUGINS_REQUIRING_CONFIG`

### 🔧 修正 MediaEmbedResize 的事实错误
旧注释称其"免费、未由 umbrella 导出"——**两处都错**：
- 它**由 umbrella 导出**（`export *` 透传 `@ckeditor/ckeditor5-media-embed`）
- 但属**功能性 premium**（`MediaEmbedResizeEditing.isPremiumPlugin===true`），GPL license 下加载会触发 license 报错

按需加载器的 import 源从子包改为 umbrella `ckeditor5`（消除混用入口的双实例风险）；JavaDoc / TS 注释 / warn 文案全部同步。

### ⚠️ BREAKING：移除免费 `CKEditorPlugin.LINE_HEIGHT`
`LineHeight` 在 48.x 属 premium（仅 `ckeditor5-premium-features` 导出、`isPremiumPlugin===true`），且原本就没注册进 TS registry，选它会得到运行时 `Plugin not found` 错误。premium 侧 `VaadinCKEditorPremium.PremiumPlugin.LINE_HEIGHT` 已有正确定义。

**迁移**：`addCustomPlugin(CustomPlugin.fromPremium("LineHeight"))` + 配置商业 license key

## 测试

- 新增 `CKEditorPluginTest` 用例（新常量 + LineHeight 移除断言）
- 新增 `plugin-resolver.test.ts` CKFinder require-config 覆盖（默认过滤 / 显式放行 / requiresConfiguration）

## 文档
- `docs/USER_GUIDE.md`：更新插件列表 + premium 迁移注解
- `CHANGELOG.md`：Added / Changed / Removed（含 Breaking 迁移）
- `docs/PLUGIN_GAP_ANALYSIS.md`（新增）：完整免费/付费差集分析与核验依据

## 验证

- `npm test` → **171/171** ✅
- `npm run typecheck` → clean ✅
- `mvn clean test` → **542/542** ✅
- Codex 交叉审查两轮，最终 **90/100，通过**

🤖 Generated with [Claude Code](https://claude.com/claude-code)