### PR TITLE
feat: ckeditor-vaadin-testbench module + plugin gap fixes; release 5.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upload Test Reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports
           path: target/surefire-reports/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,19 +20,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
           cache: maven
 
-      - name: Setup Node 22
-        uses: actions/setup-node@v4
+      - name: Setup Node 24
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: e2e/package-lock.json
 
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: e2e/playwright-report/
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload test traces on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-test-results
           path: e2e/test-results/

--- a/.github/workflows/publish-testbench.yml
+++ b/.github/workflows/publish-testbench.yml
@@ -1,0 +1,131 @@
+name: Publish TestBench Module to Maven Central
+
+# 独立发布可选的 ckeditor-vaadin-testbench 模块。
+# 与主模块 publish.yml 解耦：用 testbench-v* tag 或手动 dispatch 触发，
+# 不影响主模块的 v* 发布流程。复用同一套 Sonatype Central + GPG secrets。
+
+on:
+  push:
+    tags:
+      - "testbench-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 5.3.0) - must match ckeditor-vaadin-testbench/pom.xml"
+        type: string
+        required: true
+      draft:
+        description: "Create GitHub release as draft"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    working-directory: ckeditor-vaadin-testbench
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ -z "${INPUT_VERSION:-}" ]]; then
+              echo "::error::Version input is required for manual trigger."
+              exit 1
+            fi
+            VERSION="${INPUT_VERSION}"
+            TAG_NAME="testbench-v${VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+            if [[ ! "$TAG_NAME" =~ ^testbench-v ]]; then
+              echo "::error::Tag must start with testbench-v followed by version (e.g. testbench-v5.3.0)."
+              exit 1
+            fi
+            VERSION="${TAG_NAME#testbench-v}"
+          fi
+
+          # Strict SemVer validation of the resolved version (applies to both trigger paths).
+          # Full-string match avoids accepting partial/garbage versions like "5.3.0-typo".
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected X.Y.Z or X.Y.Z-suffix (e.g. 5.3.0, 5.3.0-rc1)."
+            exit 1
+          fi
+
+          # Verify the testbench module pom.xml version matches
+          POM_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ "$POM_VERSION" != "$VERSION" ]]; then
+            echo "::error::ckeditor-vaadin-testbench/pom.xml version ($POM_VERSION) does not match release version ($VERSION)"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          echo "Resolved version: $VERSION (matches ckeditor-vaadin-testbench/pom.xml)"
+
+      - name: Publish to Maven Central
+        run: mvn -B -ntp clean deploy -Prelease
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          name: testbench-v${{ steps.version.outputs.version }}
+          draft: ${{ inputs.draft || false }}
+          generate_release_notes: true
+          files: |
+            ckeditor-vaadin-testbench/target/ckeditor-vaadin-testbench-${{ steps.version.outputs.version }}.jar
+            ckeditor-vaadin-testbench/target/ckeditor-vaadin-testbench-${{ steps.version.outputs.version }}-sources.jar
+            ckeditor-vaadin-testbench/target/ckeditor-vaadin-testbench-${{ steps.version.outputs.version }}-javadoc.jar
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Job Summary
+        if: always()
+        run: |
+          {
+            echo "## TestBench Module Release Summary"
+            echo ""
+            echo "| Parameter | Value |"
+            echo "|-----------|-------|"
+            echo "| Version | \`${VERSION:-n/a}\` |"
+            echo "| Tag | \`${TAG_NAME:-n/a}\` |"
+            echo "| Maven Central | \`com.wontlost:ckeditor-vaadin-testbench:${VERSION:-n/a}\` |"
+            echo "| Status | \`${{ job.status }}\` |"
+            echo ""
+            if [[ "${{ job.status }}" == "success" ]]; then
+              echo "Published to [Maven Central](https://central.sonatype.com/artifact/com.wontlost/ckeditor-vaadin-testbench/${VERSION})"
+              echo ""
+              echo "Released to [GitHub Releases](https://github.com/${{ github.repository }}/releases/tag/${TAG_NAME})"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-testbench.yml
+++ b/.github/workflows/publish-testbench.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/main/resources/META-INF/frontend/vaadin-ckeditor/node_modules/
 
 # Claude/AI tools
 .claude/
+.ccg/
 .ace-tool/
 
 # OS files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.1] - 2026-06-26
+
 ### Added
 - Caret/focus control API on `VaadinCKEditor` (issue #52): `setCaretToStart()`,
   `setCaretToEnd()`, `focusEditor()`. Useful when leading block content (e.g. a
@@ -17,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MediaEmbedResize` plugin, which 48.2.0 ships only in the `@ckeditor/ckeditor5-media-embed`
   subpackage (not the `ckeditor5` umbrella); the frontend loads it on demand from the
   same-version subpackage when the flag is enabled. Requires `CKEditorPlugin.MEDIA_EMBED`.
+- Optional `ckeditor-vaadin-testbench` module providing `VaadinCKEditorElement` — a
+  type-safe Vaadin TestBench page object for the `vaadin-ckeditor` component
+  (`getData`/`setData`/`insertText`/`setReadOnly`/`focusEditor`/`setCaretToStart`/`End`
+  plus key property getters). Vaadin TestBench is a commercial (Premium) feature: the
+  module depends on `vaadin-testbench-core` with `provided` scope and does not bundle
+  TestBench at runtime, so the core addon stays free of the Premium dependency. Consumers
+  bring their own TestBench dependency and license to run tests.
 
 ## [5.3.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself is free (umbrella-exported); using it requires `config.ckfinder.uploadUrl` and
   a CKFinder server backend, so it is treated as a config-required plugin (filtered out
   of auto-select unless `setAllowConfigRequiredPlugins(true)` is set).
+- `CKEditorConfig.setMediaEmbedToolbar(String...)` — fluent setter that writes media
+  toolbar buttons to `config.mediaEmbed.toolbar` (where `MediaEmbedStyle`'s alignment
+  buttons such as `mediaEmbed:alignLeft` must live, not the top-level `config.toolbar`).
+  Empty/null input writes nothing (no empty-array noise).
 
 ### Changed
 - `media-embed-resize.ts`: the on-demand `MediaEmbedResize` loader now imports from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the start so nothing is highlighted.
 - Resizable embedded media (issue #71): `CKEditorConfig.setMediaEmbedResizable(true)`
   enables drag-to-resize handles on embedded media (videos). Backed by CKEditor's
-  `MediaEmbedResize` plugin, which 48.2.0 ships only in the `@ckeditor/ckeditor5-media-embed`
-  subpackage (not the `ckeditor5` umbrella); the frontend loads it on demand from the
-  same-version subpackage when the flag is enabled. Requires `CKEditorPlugin.MEDIA_EMBED`.
+  `MediaEmbedResize` plugin. The frontend loads it on demand from the `ckeditor5`
+  umbrella package only when the flag is enabled; load failures (e.g. missing
+  commercial license — see below) degrade silently. Requires `CKEditorPlugin.MEDIA_EMBED`.
+- Free media-embed companion plugins, exported by the `ckeditor5` umbrella and now
+  registered as built-in `CKEditorPlugin` constants:
+  - `MEDIA_EMBED_STYLE` (`MediaEmbedStyle`) — alignment/styling for embedded media
+    (`mediaEmbed:alignLeft` / `alignCenter` / `alignRight` toolbar items); the sibling
+    feature of the resize support above. Not auto-loaded by `MEDIA_EMBED`, so it must
+    be selected explicitly.
+  - `MEDIA_EMBED_TOOLBAR` (`MediaEmbedToolbar`) — floating toolbar shown when an
+    embedded media widget is selected (hosts the style/alignment buttons).
+  - `AUTO_MEDIA_EMBED` (`AutoMediaEmbed`) — auto-converts pasted media links into embeds.
+- `CKFINDER` (`CKFinder`) — CKFinder file-manager integration plugin. The plugin class
+  itself is free (umbrella-exported); using it requires `config.ckfinder.uploadUrl` and
+  a CKFinder server backend, so it is treated as a config-required plugin (filtered out
+  of auto-select unless `setAllowConfigRequiredPlugins(true)` is set).
+
+### Changed
+- `media-embed-resize.ts`: the on-demand `MediaEmbedResize` loader now imports from the
+  `ckeditor5` umbrella package instead of the `@ckeditor/ckeditor5-media-embed` subpackage.
+  Verified against the installed 48.2.0 artifacts: the umbrella re-exports the whole
+  media-embed subpackage (`export * from '@ckeditor/ckeditor5-media-embed'`), so
+  `import { MediaEmbedResize } from 'ckeditor5'` resolves. Importing from the umbrella
+  (rather than mixing umbrella + subpackage entry points) avoids the risk of resolving
+  two distinct class instances. Corrects the prior comment that claimed the plugin was
+  "free" and "not umbrella-exported": it *is* umbrella-exported, but its
+  `MediaEmbedResizeEditing` dependency has `isPremiumPlugin === true`, so loading it under
+  a GPL license triggers CKEditor's license check — it is effectively a premium feature.
+
+### Removed
+- **Breaking:** `CKEditorPlugin.LINE_HEIGHT` removed from the free built-in plugin enum.
+  `LineHeight` is a **premium** feature in CKEditor 48.x — it is not exported by the
+  `ckeditor5` umbrella package (only by `ckeditor5-premium-features`, where its class
+  reports `isPremiumPlugin === true`) and was never registered in the TypeScript
+  `PLUGIN_REGISTRY`, so `withPlugins(CKEditorPlugin.LINE_HEIGHT)` produced a
+  "Plugin not found in registry" error at runtime. The premium definition already exists
+  as `VaadinCKEditorPremium.PremiumPlugin.LINE_HEIGHT`.
+  - **Migration:** replace `withPlugins(CKEditorPlugin.LINE_HEIGHT)` with
+    `addCustomPlugin(CustomPlugin.fromPremium("LineHeight"))` and configure a commercial
+    license key.
 
 ## [5.3.0] - 2026-06-26
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ A comprehensive CKEditor 5 integration for Vaadin 24+.
 <dependency>
     <groupId>com.wontlost</groupId>
     <artifactId>ckeditor-vaadin</artifactId>
-    <version>5.3.0</version>
+    <version>5.3.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("com.wontlost:ckeditor-vaadin:5.3.0")
+implementation("com.wontlost:ckeditor-vaadin:5.3.1")
 ```
 
 ### Compatibility Matrix
@@ -449,6 +449,35 @@ VaadinCKEditor editor = VaadinCKEditor.create()
     .withDependencyMode(DependencyMode.MANUAL)
     .build();
 ```
+
+---
+
+## Testing with TestBench (optional)
+
+An optional `ckeditor-vaadin-testbench` module provides `VaadinCKEditorElement`, a
+type-safe Vaadin TestBench page object for the `vaadin-ckeditor` component.
+
+> ⚠️ Vaadin TestBench is a **commercial (Premium)** feature. The module depends on
+> TestBench with `provided` scope and does not bundle it; you need your own TestBench
+> license to run tests. The core addon has no TestBench dependency.
+
+```xml
+<dependency>
+    <groupId>com.wontlost</groupId>
+    <artifactId>ckeditor-vaadin-testbench</artifactId>
+    <version>5.3.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+```java
+VaadinCKEditorElement editor = $(VaadinCKEditorElement.class).first();
+editor.setData("<p>Hello</p>");
+assertEquals("<p>Hello</p>", editor.getData());
+```
+
+See [`ckeditor-vaadin-testbench/README.md`](ckeditor-vaadin-testbench/README.md) for the
+full API and setup.
 
 ---
 

--- a/ckeditor-vaadin-testbench/README.md
+++ b/ckeditor-vaadin-testbench/README.md
@@ -1,0 +1,104 @@
+# ckeditor-vaadin-testbench
+
+Vaadin **TestBench** element API for the [CKEditor 5 Vaadin integration](../README.md).
+Provides `VaadinCKEditorElement` — a type-safe page object for driving the
+`vaadin-ckeditor` component in end-to-end tests.
+
+## ⚠️ Premium / License
+
+[Vaadin TestBench](https://vaadin.com/docs/latest/flow/testing/end-to-end) is a
+**commercial (Premium) feature** and requires a Vaadin subscription.
+
+- This module depends on `com.vaadin:vaadin-testbench-core` with **`provided` scope** —
+  it only needs the TestBench API at *compile time* and does **not** bundle TestBench at runtime.
+- **You must bring your own TestBench dependency and license** to actually run tests.
+- The core `ckeditor-vaadin` addon has **no** TestBench dependency; this optional module
+  keeps the Premium dependency out of the free addon.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.wontlost</groupId>
+    <artifactId>ckeditor-vaadin-testbench</artifactId>
+    <version>5.3.1</version>
+    <scope>test</scope>
+</dependency>
+```
+
+You also need TestBench itself on your test classpath (provided by your Vaadin
+subscription), e.g.:
+
+```xml
+<dependency>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-testbench-core-junit5</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+> Versions are managed by `vaadin-bom`; no explicit version is needed.
+
+## Usage
+
+```java
+import com.wontlost.ckeditor.testbench.VaadinCKEditorElement;
+import com.vaadin.testbench.TestBenchTestCase;
+
+public class EditorIT extends TestBenchTestCase {
+
+    @Test
+    public void editsContent() {
+        // locate the editor on the page
+        VaadinCKEditorElement editor = $(VaadinCKEditorElement.class).first();
+
+        // set and read content
+        editor.setData("<p>Hello</p>");
+        assertEquals("<p>Hello</p>", editor.getData());
+
+        // insert text at the caret
+        editor.setCaretToEnd();
+        editor.insertText(" world");
+
+        // toggle read-only
+        editor.setReadOnly(true);
+        assertTrue(editor.isReadOnly());
+
+        // inspect configuration
+        assertEquals("classic", editor.getEditorType());
+    }
+}
+```
+
+## API
+
+`VaadinCKEditorElement extends com.vaadin.testbench.TestBenchElement`, bound to the
+`vaadin-ckeditor` tag via `@Element("vaadin-ckeditor")`.
+
+| Method | Backed by | Description |
+|--------|-----------|-------------|
+| `String getData()` | `executeScript` → CKEditor `getData()` | Live HTML content (falls back to the `editorData` property before the editor is ready) |
+| `void setData(String html)` | `callFunction("updateData")` | Set **live** editor content. Does **not** sync the server-side `getValue()` (the update goes through the API-change path that intentionally skips `$server.setEditorData`). Assert browser content via `getData()`; for server value/Binder, drive real user input instead. |
+| `void insertText(String text)` | `callFunction("insertText")` | Insert text at the caret |
+| `void setReadOnly(boolean)` | `callFunction("setReadOnly")` | Toggle read-only |
+| `boolean isReadOnly()` | `getPropertyBoolean("isReadOnly")` | Read-only state |
+| `boolean isEnabled()` | `getPropertyBoolean("isEnabled")` | Enabled state |
+| `void focusEditor()` | `callFunction("focusEditor")` | Focus the editable area |
+| `void setCaretToStart()` / `setCaretToEnd()` | `callFunction(...)` | Move the caret |
+| `String getEditorType()` | `getPropertyString("editorType")` | `classic` / `balloon` / `inline` / `decoupled` |
+| `String getThemeType()` | `getPropertyString("themeType")` | `auto` / `light` / `dark` |
+| `String getLanguage()` | `getPropertyString("language")` | UI language code |
+| `String getFallbackMode()` | `getPropertyString("fallbackMode")` | `textarea` / `readonly` / `error` / `hidden` |
+
+The component renders into light DOM, so TestBench can also query CKEditor's DOM inside
+the element; prefer `getData()` over scraping rendered DOM for stable content assertions.
+
+## Building
+
+```bash
+mvn -f ckeditor-vaadin-testbench/pom.xml compile
+```
+
+Compilation only needs the TestBench API (resolved as `provided`); **no license is
+required to compile or distribute this module**. A license is required only to *run*
+TestBench tests in a consuming project.

--- a/ckeditor-vaadin-testbench/pom.xml
+++ b/ckeditor-vaadin-testbench/pom.xml
@@ -1,28 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.wontlost</groupId>
-    <artifactId>ckeditor-vaadin</artifactId>
+    <artifactId>ckeditor-vaadin-testbench</artifactId>
     <packaging>jar</packaging>
     <version>5.3.1</version>
-    <name>CKEditorVaadin</name>
-    <description>Integration of CKEditor 5 for Vaadin</description>
+    <name>CKEditorVaadin TestBench</name>
+    <description>
+        Optional Vaadin TestBench element API for the CKEditor 5 Vaadin integration.
+        Provides VaadinCKEditorElement for type-safe interaction in end-to-end tests.
+        Vaadin TestBench is a commercial (Premium) feature: consumers must supply their
+        own TestBench dependency and license to run tests. This module only provides the
+        compile-time element wrapper and does not bundle TestBench at runtime.
+    </description>
     <url>https://github.com/wontlost-ltd/vaadin-ckeditor</url>
+
     <scm>
         <url>https://github.com/wontlost-ltd/vaadin-ckeditor</url>
         <connection>scm:git:https://github.com/wontlost-ltd/vaadin-ckeditor.git</connection>
         <developerConnection>scm:git:git@github.com:wontlost-ltd/vaadin-ckeditor.git</developerConnection>
     </scm>
+
     <properties>
         <vaadin.version>25.2.0</vaadin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
     <organization>
         <name>WontLost Ltd</name>
     </organization>
+
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -30,6 +42,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <developers>
         <developer>
             <name>WontLost Ltd</name>
@@ -38,8 +51,10 @@
             <organizationUrl>https://github.com/wontlost-ltd</organizationUrl>
         </developer>
     </developers>
+
     <dependencyManagement>
         <dependencies>
+            <!-- vaadin-bom 透传 vaadin-testbench-bom，统一管理 TestBench 各 artifact 版本 -->
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
@@ -47,99 +62,41 @@
                 <scope>import</scope>
                 <version>${vaadin.version}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!-- Vaadin (provided - supplied by consuming application) -->
+        <!--
+            Vaadin TestBench core（Premium / 商业 license）。
+            scope=provided：仅编译期需要 TestBenchElement / @Element API；
+            运行测试的消费方自带 TestBench 依赖与 license，本模块不在 runtime 强加 TestBench。
+            版本由 vaadin-bom → vaadin-testbench-bom 管理，无需显式声明。
+        -->
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
+            <artifactId>vaadin-testbench-core</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Jackson JSON 3.x (provided - used by Vaadin 25+ for setPropertyJson) -->
-        <dependency>
-            <groupId>tools.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>3.1.4</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- HTML Sanitization -->
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.18.3</version>
-        </dependency>
-
-        <!-- Jakarta Servlet API (provided - Vaadin 25+) -->
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>6.0.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.27.7</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
-                    <archive>
-                        <index>true</index>
-                        <manifest>
-                            <addClasspath>false</addClasspath>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                        <manifestEntries>
-                            <Vaadin-Package-Version>1</Vaadin-Package-Version>
-                        </manifestEntries>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                    <excludes>
-                        <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
-                        <exclude>**/node_modules/**</exclude>
-                        <exclude>**/package-lock.json</exclude>
-                        <exclude>**/tsconfig.json</exclude>
-                    </excludes>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>7.2.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>bnd-process</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
 
+    <!--
+        release profile：与主模块一致，发布到 Maven Central（Sonatype Central Portal）。
+        激活方式：mvn -Prelease deploy。需要 CENTRAL_USERNAME/CENTRAL_PASSWORD 与 GPG 配置。
+        Maven Central 强制要求 source jar、javadoc jar 与 GPG 签名，故全部在此 profile 中附加。
+    -->
     <profiles>
         <profile>
             <id>release</id>

--- a/ckeditor-vaadin-testbench/src/main/java/com/wontlost/ckeditor/testbench/VaadinCKEditorElement.java
+++ b/ckeditor-vaadin-testbench/src/main/java/com/wontlost/ckeditor/testbench/VaadinCKEditorElement.java
@@ -1,0 +1,170 @@
+package com.wontlost.ckeditor.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * Vaadin TestBench element（page object）for the CKEditor 5 integration component
+ * （前端标签 {@code vaadin-ckeditor}）。
+ *
+ * <p>在 Vaadin TestBench 端到端测试中以类型安全的方式操作编辑器，例如：</p>
+ * <pre>{@code
+ * VaadinCKEditorElement editor = $(VaadinCKEditorElement.class).first();
+ * editor.setData("<p>Hello</p>");
+ * assertEquals("<p>Hello</p>", editor.getData());
+ * }</pre>
+ *
+ * <p><b>Premium 说明</b>：Vaadin TestBench 是商业（Premium）功能。本类仅在编译期依赖
+ * TestBench API（{@code vaadin-testbench-core}，scope=provided），不在运行时强加 TestBench。
+ * 运行测试的使用者须自备 TestBench 依赖与 license。</p>
+ *
+ * <p><b>方法映射</b>：</p>
+ * <ul>
+ *   <li>读属性 → {@code getPropertyString/getPropertyBoolean}（编辑器同步到 server 的属性值）</li>
+ *   <li>调前端方法 → {@code callFunction}（对应 {@code VaadinCKEditor} 上的公开方法）</li>
+ *   <li>取实时内容 → {@code executeScript} 调用 CKEditor 实例的 {@code getData()}</li>
+ * </ul>
+ */
+@Element("vaadin-ckeditor")
+public class VaadinCKEditorElement extends TestBenchElement {
+
+    // ==================== 内容读写 ====================
+
+    /**
+     * 获取编辑器的实时 HTML 内容。
+     *
+     * <p>优先调用 CKEditor 实例的 {@code getData()} 取最新内容；编辑器尚未就绪时
+     * 回退到已同步的 {@code editorData} 属性。这比抓取渲染 DOM 更稳定。</p>
+     *
+     * <p>实现依赖前端元素上运行时可达的 {@code editor} 字段。若前端日后将其改为
+     * ECMAScript {@code #private} 或重命名，此方法需相应调整（或前端补一个 public getter）。</p>
+     *
+     * @return 当前 HTML 内容
+     */
+    public String getData() {
+        Object result = executeScript(
+            "return arguments[0].editor ? arguments[0].editor.getData() : arguments[0].editorData;",
+            this);
+        return result != null ? result.toString() : "";
+    }
+
+    /**
+     * 设置编辑器的 live 内容（调用前端 {@code updateData}，写入 CKEditor 实例）。
+     *
+     * <p><b>注意语义边界</b>：该方法只改变浏览器端 CKEditor 的 live 内容，<b>不保证</b>同步到
+     * server 端的 {@code VaadinCKEditor#getValue()}。前端 {@code updateData} 走 API 变更路径
+     * （{@code apiChangeDepth>0}），按设计不会回写 {@code $server.setEditorData()}，以免反向污染
+     * Binder。因此：用 {@link #getData()} 断言浏览器端内容是可靠的；若要断言 server 端 value /
+     * Binder / valueChange，应通过真实用户输入路径（如点击编辑区后键入），而非本方法。</p>
+     *
+     * @param html 要设置的 HTML 内容
+     */
+    public void setData(String html) {
+        callFunction("updateData", html);
+    }
+
+    /**
+     * 在当前/上次记录的光标位置插入文本（调用前端 {@code insertText}）。
+     *
+     * @param text 要插入的文本
+     */
+    public void insertText(String text) {
+        callFunction("insertText", text);
+    }
+
+    // ==================== 状态控制 ====================
+
+    /**
+     * 设置只读状态（调用前端 {@code setReadOnly}）。
+     *
+     * @param readOnly true 设为只读
+     */
+    public void setReadOnly(boolean readOnly) {
+        callFunction("setReadOnly", readOnly);
+    }
+
+    /**
+     * 是否只读。读取本组件同步的 {@code isReadOnly} 属性，而非通用 readonly attribute，
+     * 更贴近 CKEditor integration 的状态。
+     *
+     * @return true 表示只读
+     */
+    public boolean isReadOnly() {
+        return getPropertyBoolean("isReadOnly");
+    }
+
+    /**
+     * 是否启用。
+     *
+     * <p>覆盖 {@link TestBenchElement} 继承自 Selenium {@code WebElement} 的 {@code isEnabled()}：
+     * 返回本组件同步的 {@code isEnabled} 属性（与 Java 侧 {@code onEnabledStateChanged} 一致），
+     * 而非通用 WebElement 可交互性判断。</p>
+     *
+     * @return true 表示启用
+     */
+    @Override
+    public boolean isEnabled() {
+        return getPropertyBoolean("isEnabled");
+    }
+
+    // ==================== 焦点 / 光标 ====================
+
+    /**
+     * 聚焦编辑器可编辑区（调用前端 {@code focusEditor}）。
+     */
+    public void focusEditor() {
+        callFunction("focusEditor");
+    }
+
+    /**
+     * 将光标移到内容开头（调用前端 {@code setCaretToStart}）。
+     */
+    public void setCaretToStart() {
+        callFunction("setCaretToStart");
+    }
+
+    /**
+     * 将光标移到内容末尾（调用前端 {@code setCaretToEnd}）。
+     */
+    public void setCaretToEnd() {
+        callFunction("setCaretToEnd");
+    }
+
+    // ==================== 关键属性读取 ====================
+
+    /**
+     * 编辑器类型：classic / balloon / inline / decoupled。
+     *
+     * @return {@code editorType} 属性值
+     */
+    public String getEditorType() {
+        return getPropertyString("editorType");
+    }
+
+    /**
+     * 主题类型：auto / light / dark。
+     *
+     * @return {@code themeType} 属性值
+     */
+    public String getThemeType() {
+        return getPropertyString("themeType");
+    }
+
+    /**
+     * UI 语言代码。
+     *
+     * @return {@code language} 属性值
+     */
+    public String getLanguage() {
+        return getPropertyString("language");
+    }
+
+    /**
+     * 回退模式：textarea / readonly / error / hidden。
+     *
+     * @return {@code fallbackMode} 属性值
+     */
+    public String getFallbackMode() {
+        return getPropertyString("fallbackMode");
+    }
+}

--- a/docs/PLUGIN_GAP_ANALYSIS.md
+++ b/docs/PLUGIN_GAP_ANALYSIS.md
@@ -1,0 +1,172 @@
+# CKEditor 插件差集分析报告（ckeditor5 48.2.0）
+
+> 本报告核对 CKEditor 5 官方 `ckeditor5`（免费）与 `ckeditor5-premium-features`（付费）
+> 两个 umbrella 包在 **48.2.0** 版本的插件全集，与本库（vaadin-ckeditor）当前支持范围做差集，
+> 给出补全决策与实施结果。
+>
+> **核验方法**：双链交叉验证。
+> 1. **一手 import 证据** — 本地安装 `ckeditor5@48.2.0` + `ckeditor5-premium-features@48.2.0`，
+>    在 jsdom 提供 DOM 后真实 ESM `import`，读取 **1473 个 umbrella 导出键**与 premium 包导出，
+>    并逐个核验插件类的静态 `isPremiumPlugin` gate。
+> 2. **Workflow 65-agent 网络核验** — 对抗性验证插件 tier/source，结论与一手证据完全一致。
+>
+> ⚠️ 过程教训：对 minify 后的 runtime bundle 做 `grep` / `es-module-lexer` 均产生**伪证据**
+> （类名被改写、`export *` 转发不展开），唯有**真实 import 解析**给出真相。涉及 CKEditor 包导出
+> 结构的判断，必须以真实 import 为准，不可凭 bundle 文本或文档转述。
+
+---
+
+## 1. 核心架构回顾：本库的三条插件加载路径
+
+| 类型 | Java 入口 | TS 加载方式 | 是否需逐个登记 |
+|------|-----------|-------------|----------------|
+| **标准免费插件** | `withPlugins(CKEditorPlugin.X)` | 静态 `PLUGIN_REGISTRY` 查表 | **是**（枚举 + registry 双侧） |
+| **Premium 插件** | `addCustomPlugin(CustomPlugin.fromPremium("X"))` | 运行时 `import('ckeditor5-premium-features')` 按名取 | **否**（generic channel，任意名生效） |
+| **第三方/自研** | `addCustomPlugin(CustomPlugin.withImportPath("..."))` | 动态 `import(importPath)` | **否** |
+
+关键差异：
+- **免费插件**走静态 registry，必须在 `CKEditorPlugin` 枚举 + `plugin-resolver.ts` 的 `PLUGIN_REGISTRY`
+  各登记一行才能用。这是"免费差集"的实际含义。
+- **Premium 插件**走 generic channel，`fromPremium(anyName)` 对 `ckeditor5-premium-features` 的
+  任意导出生效。因此"premium 差集"在**功能层面不存在**。
+
+---
+
+## 2. 关键裁决（一手证据锁定）
+
+| 插件 | umbrella 导出 | 类 `isPremiumPlugin` | 依赖链 premium gate | 真实 tier | 本库原认知 |
+|------|:---:|:---:|:---:|------|------|
+| `MediaEmbedStyle` | ✅ | false | `StyleEditing` = false | **真免费** | 未收录 |
+| `MediaEmbedToolbar` | ✅ | false | — | **真免费** | 未收录 |
+| `AutoMediaEmbed` | ✅ | false | — | **真免费** | 未收录 |
+| `MediaEmbedResize` | ✅ | false | **`ResizeEditing` = TRUE** | **功能 premium** | ❌ 注释称"免费、未由 umbrella 导出" |
+| `TableLayout` | ✅ | false | **`LayoutEditing` = TRUE** | **功能 premium** | ✅ 已正确归 premium |
+| `LineHeight` | ❌ | premium 包 = TRUE | — | **premium** | ❌ 免费枚举里错误登记 |
+
+### 2.1 "功能性 premium" 概念
+
+部分插件的 **glue 类**本身 `isPremiumPlugin === false`（看起来免费），但其 `requires` 依赖链上的
+`*Editing` 子插件 `isPremiumPlugin === true`。CKEditor 的 license 校验按依赖链整体判定：在 GPL license 下
+加载这类插件会触发 license 报错。`MediaEmbedResize`、`TableLayout` 即属此类——**umbrella 可 import，但功能需商业 license**。
+
+### 2.2 `MediaEmbedResize` 真相
+
+本库 `media-embed-resize.ts` 旧注释断言"48.2.0 未由 umbrella 导出，只在 `@ckeditor/ckeditor5-media-embed` 子包"。
+**这是错的**：
+
+- `ckeditor5@48.2.0/dist/index.d.ts` 与 `dist/ckeditor5.js` 通过 `export * from '@ckeditor/ckeditor5-media-embed'`
+  把整个子包（含 `MediaEmbedResize`/`MediaEmbedStyle`）透传到 umbrella，`import { MediaEmbedResize } from 'ckeditor5'` 可解析。
+- 但它是功能性 premium（`MediaEmbedResizeEditing.isPremiumPlugin === true`），不是免费 GPL。
+
+**结论**：保留"按需隔离加载 + 失败静默"的设计（正确，避免无 license 用户崩溃），但
+（a）订正注释，（b）import 源由子包改为 umbrella `ckeditor5`，消除"静态 umbrella + 动态子包"双入口可能解析到
+不同类实例的风险。**不**并入免费 registry。
+
+---
+
+## 3. 免费插件差集
+
+### 3.1 已实施补全
+
+| 优先级 | 插件 | Java 枚举常量 | 说明 | 加载特性 |
+|:---:|------|------|------|------|
+| **P0** | `MediaEmbedStyle` | `MEDIA_EMBED_STYLE` | resize 的姊妹特性，媒体对齐/排版样式。**不被 `MediaEmbed` 自动加载**，需显式选择 | 标准 registry |
+| **P1** | `MediaEmbedToolbar` | `MEDIA_EMBED_TOOLBAR` | 选中媒体时的浮动工具栏，承载 style/对齐按钮 | 标准 registry |
+| **P1** | `AutoMediaEmbed` | `AUTO_MEDIA_EMBED` | 粘贴链接自动转嵌入 | 标准 registry |
+| **P2** | `CKFinder` | `CKFINDER` | 文件管理集成；类免费但需 `config.ckfinder.uploadUrl` + 服务端 | 标准 registry + **require-config** |
+
+`CKFinder` 已加入 `plugin-resolver.ts` 的 `PLUGINS_REQUIRING_CONFIG`，自动全选时被过滤，
+显式配置后通过 `setAllowConfigRequiredPlugins(true)` 放行。
+
+### 3.2 不予补全的项（及理由）
+
+Workflow confirmedGaps 列出 60 个"umbrella 有、本库 registry 无"的导出，但绝大多数**不应**单独登记：
+
+| 类别 | 示例 | 不补的理由 |
+|------|------|------|
+| glue plugin 的内部子组件 | `BoldEditing`、`BoldUI`、`MediaEmbedEditing`、`MediaEmbedUI`、`AlignmentEditing` 等 | 已被对应 glue plugin（registry 已有 `Bold`/`MediaEmbed`/`Alignment`）通过 `requires` **自动加载**，单独登记纯属噪音 |
+| 包自动加载的依赖 | `TableClipboard`、`TableKeyboard`、`TableMouse`、`TableSelection` | `Table` 自动加载，无需用户感知 |
+| Essentials 成员 | `Enter`、`ShiftEnter`、`Delete`、`Input`、`Typing` | `Essentials`（registry 已有）自动加载二者 |
+| ContextPlugin / 工具类 | `PendingActions`、`ClipboardPipeline`、`ClipboardMarkersUtils`、`*Utils` | 多被其他插件依赖自动加载，单独登记价值低 |
+| Legacy 废弃类 | `LegacyList`、`LegacyListProperties`、`LegacyTodoList` | 废弃，不应暴露 |
+| 功能性 premium | `CKBox`、`CKBoxImageEdit` 系列 | 类在 umbrella，但功能需商业 license + 另装 `ckbox` 包；走 premium/custom 通道，不进免费 registry |
+
+> 设计原则：免费 registry 只登记**用户需显式选择的 glue plugin**，不登记会被自动加载的子组件
+> （"消灭特殊情况"，避免 registry 膨胀）。
+
+### 3.3 真正需独立包的免费插件
+
+- **`Mermaid`**（流程图/图表）：唯一确凿的"官方免费但不在 umbrella、需独立 npm 包"案例
+  （`@ckeditor/ckeditor5-mermaid`），且官方标注 **experimental，不推荐生产**。
+- **建议**：不收进库。需要的用户用 `CustomPlugin.withImportPath("@ckeditor/ckeditor5-mermaid")` 自助加载。
+
+---
+
+## 4. 付费插件差集
+
+### 4.1 功能层面：无差集
+
+`CustomPlugin.fromPremium(jsName)` 走 `loadPremiumPlugins`（`plugin-resolver.ts`），执行
+`(await import('ckeditor5-premium-features'))[jsName]` —— 纯运行时具名查找，对 premium 包的
+**任意导出名生效**，与 `.d.ts` 是否声明无关（`.d.ts` 末尾 `export default Record<string, unknown>` 兜底）。
+
+因此本库对**全部 premium 插件已具备完整运行时支持**，付费差集在功能层面不存在。
+
+### 4.2 类型层面：`.d.ts` 补全（仅影响 DX，可选）
+
+`ckeditor5-premium-features.d.ts` 声明了 27 个名字用于 TS 类型补全。premium 包实际有 151 个有 `pluginName`
+的插件类（含 65 个顶层 glue plugin），故 `.d.ts` 存在 type-completion 差集。但补全它**只改善 IDE 自动完成**，
+不改变运行时能力。如需提升 DX，可补充常用导出（如 `LineHeight`、`Footnotes`、`Uploadcare` 等）为
+`export const X: unknown;`。**此为可选优化，本次未做**。
+
+### 4.3 边界情况：CKBox
+
+`CKBox` / `CKBoxImageEdit` 是"类在 umbrella `ckeditor5`、但功能 premium 且运行时另需 `ckbox` 服务包"的特性。
+它们**不**从 `ckeditor5-premium-features` 导出，所以 `fromPremium` 对其**无效**。正确用法：
+`CustomPlugin.of("CKBox", ...)`（从 umbrella `ckeditor5` 取）+ 用户自行 `npm i ckbox` + 商业 license。
+此为文档澄清问题，非代码差集。
+
+---
+
+## 5. 实施清单与验证
+
+### 5.1 改动文件
+
+| 文件 | 改动 |
+|------|------|
+| `CKEditorPlugin.java` | 新增 `AUTO_MEDIA_EMBED` / `MEDIA_EMBED_STYLE` / `MEDIA_EMBED_TOOLBAR` / `CKFINDER`；移除免费 `LINE_HEIGHT` |
+| `plugin-resolver.ts` | import 块 + `PLUGIN_REGISTRY` 各加 4 项；`CKFinder` 加入 `PLUGINS_REQUIRING_CONFIG` |
+| `media-embed-resize.ts` | 订正注释；动态 import 源 `@ckeditor/ckeditor5-media-embed` → `ckeditor5` |
+| `CKEditorPluginTest.java` | 新增 4 个测试方法（媒体配套插件、CKFinder、LineHeight 移除断言） |
+| `CHANGELOG.md` | Added / Changed / Removed（含 LINE_HEIGHT **Breaking** 迁移说明）；订正旧 issue #71 措辞 |
+
+### 5.2 破坏性变更
+
+`CKEditorPlugin.LINE_HEIGHT` 移除是 breaking change。
+
+**迁移**：
+```java
+// 旧（编译失败）
+.withPlugins(CKEditorPlugin.LINE_HEIGHT)
+
+// 新
+.addCustomPlugin(CustomPlugin.fromPremium("LineHeight"))
+// 并配置商业 license key
+```
+
+### 5.3 验证结果（本地可重复）
+
+- **TS**：`npm run typecheck` 通过；`npm test` → **169/169 通过**
+- **Java**：`mvn clean test` → **542/542 通过**（clean recompile，非陈旧字节码）
+
+---
+
+## 附录：核验依据（本机 48.2.0 产物）
+
+- `ckeditor5/dist/index.d.ts` 第 47 行：`export * from '@ckeditor/ckeditor5-media-embed';`
+- `@ckeditor/ckeditor5-media-embed/dist/index.d.ts`：`export { MediaEmbedResize }`、`export { MediaEmbedStyle }` 等
+- `MediaEmbedResizeEditing.isPremiumPlugin === true`（一手 import 核验）
+- `TableLayoutEditing.isPremiumPlugin === true`（一手 import 核验）
+- `ckeditor5` umbrella：1473 个导出键、293 个有 `pluginName` 的插件类
+- `ckeditor5-premium-features`：151 个有 `pluginName` 的插件类（65 个顶层 glue）
+- `LineHeight`：umbrella 不导出，premium 包导出且 `isPremiumPlugin === true`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -187,7 +187,13 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 
 **Media & Code:**
 - `MEDIA_EMBED`, `AUTO_MEDIA_EMBED`, `MEDIA_EMBED_STYLE`, `MEDIA_EMBED_TOOLBAR`, `HTML_EMBED`, `CODE_BLOCK`
-- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，与 `MEDIA_EMBED_TOOLBAR` 配合使用
+- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，须配合 `MEDIA_EMBED_TOOLBAR` 使用。
+  用 `CKEditorConfig#setMediaEmbedToolbar(...)` 设置这些按钮：
+
+```java
+config.setMediaEmbedToolbar(
+    "mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+```
 
 **Special:**
 - `HORIZONTAL_LINE`, `PAGE_BREAK`, `SPECIAL_CHARACTERS`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -168,7 +168,8 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 - `FONT_SIZE`, `FONT_FAMILY`, `FONT_COLOR`, `FONT_BACKGROUND_COLOR`
 
 **Paragraph:**
-- `HEADING`, `ALIGNMENT`, `INDENT`, `INDENT_BLOCK`, `BLOCK_QUOTE`, `LINE_HEIGHT`
+- `HEADING`, `ALIGNMENT`, `INDENT`, `INDENT_BLOCK`, `BLOCK_QUOTE`
+- 注：`LINE_HEIGHT` 在 CKEditor 48.x 属 premium，请改用 `CustomPlugin.fromPremium("LineHeight")`（需商业 license）
 
 **Lists:**
 - `LIST`, `TODO_LIST`, `LIST_PROPERTIES`
@@ -185,7 +186,8 @@ VaadinCKEditor custom = VaadinCKEditor.create()
 - `TABLE_CAPTION`, `TABLE_COLUMN_RESIZE`
 
 **Media & Code:**
-- `MEDIA_EMBED`, `HTML_EMBED`, `CODE_BLOCK`
+- `MEDIA_EMBED`, `AUTO_MEDIA_EMBED`, `MEDIA_EMBED_STYLE`, `MEDIA_EMBED_TOOLBAR`, `HTML_EMBED`, `CODE_BLOCK`
+- 注：`MEDIA_EMBED_STYLE`（媒体对齐样式）的按钮属 `config.mediaEmbed.toolbar`，与 `MEDIA_EMBED_TOOLBAR` 配合使用
 
 **Special:**
 - `HORIZONTAL_LINE`, `PAGE_BREAK`, `SPECIAL_CHARACTERS`

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -19,7 +19,7 @@ Each spec runs against Chromium and Firefox.
 
 ## Local run
 
-Prerequisites: Java 21+, Maven, Node 22+, ~300 MB of disk for Playwright browsers.
+Prerequisites: Java 21+, Maven, Node 24+, ~300 MB of disk for Playwright browsers.
 
 ```bash
 # 1. Install the addon locally so the sample can resolve it

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@playwright/test": "1.60.0",
-        "@types/node": "^22.10.0",
+        "@types/node": "^24.0.0",
         "typescript": "^5.9.3"
       }
     },
@@ -30,13 +30,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/fsevents": {
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",
-    "@types/node": "^22.10.0",
+    "@types/node": "^24.0.0",
     "typescript": "^5.9.3"
   }
 }

--- a/examples/spring-boot-sample/pom.xml
+++ b/examples/spring-boot-sample/pom.xml
@@ -24,7 +24,7 @@
         <vaadin.version>25.2.0</vaadin.version>
         <!-- Keep in sync with the root pom's <version>. Pinned so the sample exercises a
              specific addon build; bump together when the addon version changes. -->
-        <addon.version>5.3.0</addon.version>
+        <addon.version>5.3.1</addon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -249,6 +249,30 @@ public class CKEditorConfig {
         return this;
     }
 
+    /**
+     * 设置嵌入媒体的浮动工具栏按钮（写入 {@code config.mediaEmbed.toolbar}）。
+     *
+     * <p>{@code MediaEmbedStyle}（对齐/排版样式）注册的按钮（如
+     * {@code mediaEmbed:alignLeft} / {@code mediaEmbed:alignCenter} /
+     * {@code mediaEmbed:alignRight}）须放入 {@code config.mediaEmbed.toolbar}，
+     * 而非顶层 {@code config.toolbar}；配合 {@code MEDIA_EMBED_TOOLBAR} 插件，
+     * 选中媒体时这些按钮才会出现在浮动工具栏上。</p>
+     *
+     * <p>传入空数组或 {@code null} 不写入 toolbar 字段，避免产生空数组配置。</p>
+     *
+     * @param items 工具栏按钮名称
+     * @return this config for chaining
+     */
+    public CKEditorConfig setMediaEmbedToolbar(String... items) {
+        ArrayNode arr = toArrayNodeOrNull(items);
+        if (arr != null) {
+            ObjectNode mediaObj = getOrCreateMediaEmbed();
+            mediaObj.set("toolbar", arr);
+            configs.put("mediaEmbed", mediaObj);
+        }
+        return this;
+    }
+
     private ObjectNode getOrCreateMediaEmbed() {
         JsonNode existing = configs.get("mediaEmbed");
         if (existing != null && existing.isObject()) {

--- a/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorConfig.java
@@ -232,9 +232,11 @@ public class CKEditorConfig {
      * 启用/禁用嵌入媒体（视频等）的拖拽缩放（issue #71）。
      *
      * <p>启用后，选中嵌入媒体会显示四角缩放手柄，可按比例调整宽度。底层由 CKEditor 的
-     * {@code MediaEmbedResize} 插件实现——该插件在 48.2.0 中未由 umbrella {@code ckeditor5}
-     * 包导出，因此前端会在启用时按需从同版本 {@code @ckeditor/ckeditor5-media-embed} 子包
-     * 动态加载并注册，无需消费端额外配置。缩放数据以 {@code media_resized} class + 内联
+     * {@code MediaEmbedResize} 插件实现——该插件由 umbrella {@code ckeditor5} 包导出
+     * （48.2.0 通过 {@code export *} 透传 {@code @ckeditor/ckeditor5-media-embed}），
+     * 但属功能性 premium（其 {@code MediaEmbedResizeEditing} 依赖 {@code isPremiumPlugin=true}），
+     * 故前端在启用时才按需从 {@code ckeditor5} 动态加载，加载失败（如缺商业 license）静默降级，
+     * 无需消费端额外配置。缩放数据以 {@code media_resized} class + 内联
      * width 写入 {@code <figure>}，与 {@code previewsInData} 设置无关。</p>
      *
      * @param resizable true 启用拖拽缩放

--- a/src/main/java/com/wontlost/ckeditor/CKEditorPlugin.java
+++ b/src/main/java/com/wontlost/ckeditor/CKEditorPlugin.java
@@ -94,8 +94,10 @@ public enum CKEditorPlugin {
     /** Block quotes */
     BLOCK_QUOTE("BlockQuote", Category.PARAGRAPH, "blockQuote"),
 
-    /** Line height */
-    LINE_HEIGHT("LineHeight", Category.PARAGRAPH, "lineHeight"),
+    // 注意：LineHeight 在 ckeditor5 48.x 属 premium，仅由 ckeditor5-premium-features 导出
+    // （其类 isPremiumPlugin=true），umbrella ckeditor5 包不导出。请改用
+    // CustomPlugin.fromPremium("LineHeight") 并配置商业 license key。
+    // 此处不再作为免费内置插件登记。
 
     // ==================== Lists ====================
 
@@ -156,6 +158,13 @@ public enum CKEditorPlugin {
     /** Simple upload adapter */
     SIMPLE_UPLOAD_ADAPTER("SimpleUploadAdapter", Category.UPLOAD),
 
+    /**
+     * CKFinder 文件管理集成（插件类本身免费，由 umbrella ckeditor5 导出）。
+     * 需要配置 config.ckfinder.uploadUrl 与服务端 CKFinder（商业后端产品），
+     * 因此在前端被归入"需配置插件"，自动全选时会被过滤，须显式配置后启用。
+     */
+    CKFINDER("CKFinder", Category.UPLOAD),
+
     // ==================== Tables ====================
 
     /** Basic table support */
@@ -183,6 +192,16 @@ public enum CKEditorPlugin {
 
     /** Embed media from URLs */
     MEDIA_EMBED("MediaEmbed", Category.MEDIA, "mediaEmbed"),
+
+    /** 粘贴链接自动转嵌入媒体（免费，不被 MediaEmbed 自动加载，需显式启用） */
+    AUTO_MEDIA_EMBED("AutoMediaEmbed", Category.MEDIA),
+
+    /** 嵌入媒体对齐/排版样式（免费，提供 mediaEmbed:alignLeft/Center/Right 等按钮） */
+    MEDIA_EMBED_STYLE("MediaEmbedStyle", Category.MEDIA,
+        "mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight"),
+
+    /** 选中嵌入媒体时的浮动工具栏（免费，承载 style/对齐按钮） */
+    MEDIA_EMBED_TOOLBAR("MediaEmbedToolbar", Category.MEDIA),
 
     /** Embed raw HTML */
     HTML_EMBED("HtmlEmbed", Category.MEDIA, "htmlEmbed"),

--- a/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
+++ b/src/main/java/com/wontlost/ckeditor/VaadinCKEditor.java
@@ -96,7 +96,7 @@ public class VaadinCKEditor extends CustomField<String> implements HasAriaLabel 
 
     private static final Logger logger = Logger.getLogger(VaadinCKEditor.class.getName());
     /** Keep in sync with version field in vaadin-ckeditor.ts */
-    private static final String VERSION = "5.3.0";
+    private static final String VERSION = "5.3.1";
 
     /**
      * Default autosave waiting time in milliseconds.

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/media-embed-resize.ts
@@ -1,10 +1,13 @@
 /**
  * 嵌入媒体缩放插件的按需加载（issue #71）。
  *
- * CKEditor 48.2.0 的 MediaEmbedResize 是免费 GPL 插件，但未由 umbrella `ckeditor5` 包导出，
- * 只在同版本 `@ckeditor/ckeditor5-media-embed` 子包里。这里把"是否需要加载"的判断抽成纯函数
- * 便于单测，并提供一个动态 import 的加载器——仅在用户启用 setMediaEmbedResizable(true) 时
- * 才拉取子包，避免无谓打包，也规避静态混用 umbrella+子包的风险。
+ * CKEditor 48.2.0 的 MediaEmbedResize **由 umbrella `ckeditor5` 包导出**
+ * （umbrella 通过 `export * from '@ckeditor/ckeditor5-media-embed'` 透传，type 与 runtime 两层均可解析）。
+ * 但它是**功能性 premium**：其依赖 `MediaEmbedResizeEditing` 的 `isPremiumPlugin === true`，
+ * 在 GPL license 下加载会触发 CKEditor 的 license 校验报错。因此不能并入免费 PLUGIN_REGISTRY，
+ * 而是把"是否需要加载"的判断抽成纯函数便于单测，并仅在用户显式 setMediaEmbedResizable(true) 时
+ * 才从 umbrella 动态 import——既避免无谓打包，又把 premium license 失败隔离为静默跳过。
+ * 从 umbrella（而非子包）import 也消除了"静态 umbrella + 动态子包"双入口可能解析到不同类实例的风险。
  */
 
 /**
@@ -23,12 +26,13 @@ export function shouldLoadMediaEmbedResize(config: Record<string, unknown> | nul
 }
 
 /**
- * 从同版本子包动态加载 MediaEmbedResize 插件构造器。
- * 失败时返回 null（调用方据此跳过并可记录告警），不抛出以免阻断编辑器创建。
+ * 从 umbrella `ckeditor5` 包动态加载 MediaEmbedResize 插件构造器。
+ * 失败时返回 null（调用方据此跳过并可记录告警），不抛出以免阻断编辑器创建——
+ * 包括缺少商业 license 触发 premium 校验失败的场景，均静默降级。
  */
 export async function loadMediaEmbedResizePlugin(): Promise<unknown | null> {
     try {
-        const mod = await import('@ckeditor/ckeditor5-media-embed') as Record<string, unknown>;
+        const mod = await import('ckeditor5') as Record<string, unknown>;
         return mod.MediaEmbedResize ?? null;
     } catch {
         return null;

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/package-lock.json
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaadin-ckeditor",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaadin-ckeditor",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "dependencies": {
         "ckeditor5": "48.2.0",
         "lit": "^3.3.3"

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/package.json
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-ckeditor",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Vaadin CKEditor 5 Web Component",
   "type": "module",
   "scripts": {

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.test.ts
@@ -58,6 +58,23 @@ describe('filterConflictingPlugins', () => {
             expect(logger.warn).toHaveBeenCalledTimes(2);
         });
 
+        it('should remove CKFinder by default (requires uploadUrl/server config)', () => {
+            const plugins = ['Bold', 'CKFinder', 'Italic'];
+            const result = filterConflictingPlugins(plugins, logger);
+
+            expect(result.filtered).toEqual(['Bold', 'Italic']);
+            expect(result.removed).toContain('CKFinder');
+        });
+
+        it('should keep CKFinder when allowConfigRequiredPlugins is set', () => {
+            const plugins = ['Bold', 'CKFinder'];
+            const options: FilterOptions = { allowConfigRequiredPlugins: true };
+            const result = filterConflictingPlugins(plugins, logger, options);
+
+            expect(result.filtered).toContain('CKFinder');
+            expect(result.removed).not.toContain('CKFinder');
+        });
+
         it('should keep first plugin from mutually exclusive group', () => {
             const plugins = ['RestrictedEditingMode', 'StandardEditingMode'];
             const result = filterConflictingPlugins(plugins, logger);
@@ -355,6 +372,7 @@ describe('PluginResolver', () => {
 
         it('should check if plugin requires configuration', () => {
             expect(resolver.requiresConfiguration('Minimap')).toBe(true);
+            expect(resolver.requiresConfiguration('CKFinder')).toBe(true);
             expect(resolver.requiresConfiguration('Bold')).toBe(false);
         });
     });

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/plugin-resolver.ts
@@ -53,6 +53,7 @@ import {
     // Upload adapters
     Base64UploadAdapter,
     SimpleUploadAdapter,
+    CKFinder,
     // Tables
     Table,
     TableToolbar,
@@ -63,6 +64,9 @@ import {
     PlainTableOutput,
     // Media
     MediaEmbed,
+    AutoMediaEmbed,
+    MediaEmbedStyle,
+    MediaEmbedToolbar,
     HtmlEmbed,
     // Code
     CodeBlock,
@@ -207,6 +211,7 @@ export const PLUGIN_REGISTRY: Record<string, PluginConstructor> = {
     // Upload adapters
     'Base64UploadAdapter': Base64UploadAdapter,
     'SimpleUploadAdapter': SimpleUploadAdapter,
+    'CKFinder': CKFinder,
     // Tables
     'Table': Table,
     'TableToolbar': TableToolbar,
@@ -217,6 +222,9 @@ export const PLUGIN_REGISTRY: Record<string, PluginConstructor> = {
     'PlainTableOutput': PlainTableOutput,
     // Media
     'MediaEmbed': MediaEmbed,
+    'AutoMediaEmbed': AutoMediaEmbed,
+    'MediaEmbedStyle': MediaEmbedStyle,
+    'MediaEmbedToolbar': MediaEmbedToolbar,
     'HtmlEmbed': HtmlEmbed,
     // Code
     'CodeBlock': CodeBlock,
@@ -304,6 +312,9 @@ const PLUGINS_REQUIRING_CONFIG: readonly string[] = [
     'CloudServicesCore',
     'CloudServicesUploadAdapter',
     'EasyImage',
+    // CKFinder 需要 config.ckfinder.uploadUrl / 服务端 CKFinder，缺配置会报错，
+    // 故从"全选"中过滤；显式配置后通过 allowConfigRequiredPlugins 放行。
+    'CKFinder',
 ];
 
 /**

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -324,7 +324,7 @@ export class VaadinCKEditor extends LitElement {
     private $server?: VaadinServer;
 
     // Version info — keep in sync with VaadinCKEditor.java VERSION constant
-    private readonly version = '5.3.0';
+    private readonly version = '5.3.1';
 
     constructor() {
         super();

--- a/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
+++ b/src/main/resources/META-INF/frontend/vaadin-ckeditor/vaadin-ckeditor.ts
@@ -563,15 +563,16 @@ export class VaadinCKEditor extends LitElement {
             logger.debug('CommentPermissionEnforcer plugin injected');
         }
 
-        // 嵌入媒体缩放（issue #71）：MediaEmbedResize 不在 umbrella ckeditor5 包，
-        // 启用时从同版本子包按需动态加载并注册。
+        // 嵌入媒体缩放（issue #71）：MediaEmbedResize 由 umbrella ckeditor5 导出，
+        // 但属功能性 premium（依赖的 editing 子插件 isPremiumPlugin=true），
+        // 故启用时才从 ckeditor5 按需动态加载，加载失败（如缺 license）静默降级。
         if (shouldLoadMediaEmbedResize(this.config)) {
             const resizePlugin = await loadMediaEmbedResizePlugin();
             if (resizePlugin) {
                 resolvedPlugins.push(resizePlugin);
                 logger.debug('MediaEmbedResize plugin injected');
             } else {
-                logger.warn('MediaEmbedResize requested but could not be loaded from @ckeditor/ckeditor5-media-embed');
+                logger.warn('MediaEmbedResize requested but could not be loaded from ckeditor5 (a commercial license may be required)');
             }
         }
 

--- a/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorConfigTest.java
@@ -153,6 +153,69 @@ class CKEditorConfigTest {
     }
 
     @Test
+    @DisplayName("setMediaEmbedToolbar should write items to mediaEmbed.toolbar")
+    void setMediaEmbedToolbarShouldWriteItems() {
+        config.setMediaEmbedToolbar("mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").has("toolbar")).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(3);
+        assertThat(json.get("mediaEmbed").get("toolbar").get(0).asString())
+            .isEqualTo("mediaEmbed:alignLeft");
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar should coexist with resizable on the same mediaEmbed object")
+    void setMediaEmbedToolbarShouldCoexistWithResizable() {
+        config.setMediaEmbedResizable(true)
+              .setMediaEmbedToolbar("mediaEmbed:alignCenter");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").get("resizable").asBoolean()).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar with empty/null does not write a toolbar field")
+    void setMediaEmbedToolbarEmptyShouldNotWriteField() {
+        config.setMediaEmbedToolbar();
+        ObjectNode json = config.toJson();
+        assertThat(json.has("mediaEmbed")).isFalse();
+
+        config.setMediaEmbedToolbar((String[]) null);
+        assertThat(config.toJson().has("mediaEmbed")).isFalse();
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar coexists with setMediaEmbed regardless of call order")
+    void setMediaEmbedToolbarCoexistsWithSetMediaEmbedEitherOrder() {
+        // toolbar 先、previewsInData 后
+        config.setMediaEmbedToolbar("mediaEmbed:alignCenter").setMediaEmbed(true);
+        ObjectNode json = config.toJson();
+        assertThat(json.get("mediaEmbed").get("previewsInData").asBoolean()).isTrue();
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(1);
+
+        // 反向顺序：previewsInData 先、toolbar 后
+        CKEditorConfig reversed = new CKEditorConfig();
+        reversed.setMediaEmbed(false).setMediaEmbedToolbar("mediaEmbed:alignLeft");
+        ObjectNode rjson = reversed.toJson();
+        assertThat(rjson.get("mediaEmbed").get("previewsInData").asBoolean()).isFalse();
+        assertThat(rjson.get("mediaEmbed").get("toolbar")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("setMediaEmbedToolbar last non-empty call overwrites previous toolbar")
+    void setMediaEmbedToolbarLastCallWins() {
+        config.setMediaEmbedToolbar("mediaEmbed:alignLeft")
+              .setMediaEmbedToolbar("mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+        ObjectNode json = config.toJson();
+
+        assertThat(json.get("mediaEmbed").get("toolbar")).hasSize(2);
+        assertThat(json.get("mediaEmbed").get("toolbar").get(0).asString())
+            .isEqualTo("mediaEmbed:alignCenter");
+    }
+
+    @Test
     @DisplayName("setMediaEmbedResizable defaults to false when never set")
     void isMediaEmbedResizableDefaultsFalse() {
         assertThat(config.isMediaEmbedResizable()).isFalse();

--- a/src/test/java/com/wontlost/ckeditor/CKEditorPluginTest.java
+++ b/src/test/java/com/wontlost/ckeditor/CKEditorPluginTest.java
@@ -103,4 +103,39 @@ class CKEditorPluginTest {
         assertThat(CKEditorPlugin.STYLE.getCategory()).isEqualTo(CKEditorPlugin.Category.HTML);
         assertThat(CKEditorPlugin.STYLE.getJsName()).isEqualTo("Style");
     }
+
+    @Test
+    @DisplayName("新增的免费 media-embed 配套插件应存在且分类正确")
+    void mediaEmbedCompanionFreePluginsShouldExist() {
+        assertThat(CKEditorPlugin.AUTO_MEDIA_EMBED.getJsName()).isEqualTo("AutoMediaEmbed");
+        assertThat(CKEditorPlugin.AUTO_MEDIA_EMBED.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getJsName()).isEqualTo("MediaEmbedStyle");
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+        assertThat(CKEditorPlugin.MEDIA_EMBED_STYLE.getToolbarItems())
+            .contains("mediaEmbed:alignLeft", "mediaEmbed:alignCenter", "mediaEmbed:alignRight");
+
+        assertThat(CKEditorPlugin.MEDIA_EMBED_TOOLBAR.getJsName()).isEqualTo("MediaEmbedToolbar");
+        assertThat(CKEditorPlugin.MEDIA_EMBED_TOOLBAR.getCategory()).isEqualTo(CKEditorPlugin.Category.MEDIA);
+    }
+
+    @Test
+    @DisplayName("CKFinder 应作为免费上传类插件存在")
+    void ckFinderShouldExistAsUploadPlugin() {
+        assertThat(CKEditorPlugin.CKFINDER.getJsName()).isEqualTo("CKFinder");
+        assertThat(CKEditorPlugin.CKFINDER.getCategory()).isEqualTo(CKEditorPlugin.Category.UPLOAD);
+    }
+
+    @Test
+    @DisplayName("LineHeight 不应再出现在免费插件枚举中（实为 premium）")
+    void lineHeightShouldNotBeAFreePlugin() {
+        // LineHeight 在 ckeditor5 48.x 属 premium（见 VaadinCKEditorPremium.PremiumPlugin.LINE_HEIGHT），
+        // 不由 umbrella ckeditor5 导出，故不得作为免费内置插件存在。
+        assertThat(CKEditorPlugin.fromJsName("LineHeight")).isNull();
+        for (CKEditorPlugin plugin : CKEditorPlugin.values()) {
+            assertThat(plugin.getJsName())
+                .as("免费枚举不应包含 LineHeight")
+                .isNotEqualTo("LineHeight");
+        }
+    }
 }


### PR DESCRIPTION
## 概述

汇总发布 **5.3.1**。本 PR **包含了 #116 的全部内容**（已 merge 进本分支），外加新的 TestBench 集成模块与发布配置。合并后全量测试通过。

> ⚠️ 本 PR 已含 #116，合并本 PR 后可关闭 #116（避免重复）。

## 内容

### 1. 新增 `ckeditor-vaadin-testbench` 可选模块
- `VaadinCKEditorElement`（`extends TestBenchElement` + `@Element("vaadin-ckeditor")`）—— 类型安全的 TestBench page object：`getData`/`setData`/`insertText`/`setReadOnly`/`isReadOnly`/`isEnabled`/`focusEditor`/`setCaretToStart/End` + 关键属性 getter
- **Premium 隔离**：`vaadin-testbench-core` 用 `provided` scope，核心 addon 不依赖 TestBench；消费方自备 TestBench 依赖与 license
- **独立模块**：主 pom 未动，作为独立 sibling artifact `com.wontlost:ckeditor-vaadin-testbench`
- **发布**：`.github/workflows/publish-testbench.yml`（`testbench-v*` tag 触发，Sonatype Central + GPG，与核心同套 secrets）

### 2. 来自 #116 —— 插件差集补全 + tier 修正
- 新增免费插件 `MEDIA_EMBED_STYLE` / `MEDIA_EMBED_TOOLBAR` / `AUTO_MEDIA_EMBED` / `CKFINDER`
- 修正 `MediaEmbedResize`（umbrella 导出 + 功能性 premium，import 源改 umbrella）
- **BREAKING**：移除免费 `CKEditorPlugin.LINE_HEIGHT`（实为 premium）→ 迁移 `CustomPlugin.fromPremium("LineHeight")`
- 新增 `CKEditorConfig.setMediaEmbedToolbar(String...)`
- `docs/PLUGIN_GAP_ANALYSIS.md` 完整差集分析

### 3. 版本 5.3.0 → 5.3.1
所有 artifact 引用统一（poms、Java VERSION、前端 package.json + ts、examples、README）；CHANGELOG `[Unreleased]` → `[5.3.1]`。

## 测试（合并后全量）

- Java：`mvn clean test` → **547/547** ✅
- TS：`npm test` → **171/171** ✅，`tsc --noEmit` clean ✅
- testbench 模块：`mvn clean package` → BUILD SUCCESS（5.3.1 jar）✅
- 本地 install 两模块到 m2（5.3.1）已验证

## 审查
- Codex 三轮交叉审查：插件改动 90/93，testbench element 8.4/10，发布配置 8.8/10，均通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)